### PR TITLE
feat: 🕒 セッション期限表示の改善とリアルタイム更新

### DIFF
--- a/moodeSky/src/lib/components/AccountCard.svelte
+++ b/moodeSky/src/lib/components/AccountCard.svelte
@@ -12,9 +12,17 @@
   import ReauthModal from './ReauthModal.svelte';
   import { ICONS } from '$lib/types/icon.js';
   import type { Account } from '$lib/types/auth.js';
-  import { getTokenRemainingSeconds, isTokenExpired } from '$lib/utils/jwt.js';
-  import { calculateTimeRemaining, getWarningLevelClass, getWarningLevelIcon, getNextUpdateInterval } from '$lib/utils/timeUtils.js';
+  import { getTokenRemainingSeconds, isTokenExpired, getTokenExpiration } from '$lib/utils/jwt.js';
+  import { 
+    calculateTimeRemaining, 
+    getWarningLevelClass, 
+    getWarningLevelIcon, 
+    getOptimalUpdateInterval,
+    formatAbsoluteDate,
+    getDetailedExpirationInfo
+  } from '$lib/utils/timeUtils.js';
   import type { TimeRemaining } from '$lib/utils/timeUtils.js';
+  import { useTranslation } from '$lib/utils/reactiveTranslation.svelte.js';
   import * as m from '../../paraglide/messages.js';
 
   // ===================================================================
@@ -49,7 +57,12 @@
   
   // リフレッシュトークン期限管理
   let tokenTimeRemaining = $state<TimeRemaining | null>(null);
+  let expirationDate = $state<Date | null>(null);
   let updateTimer: ReturnType<typeof setTimeout> | null = null;
+  let isPageVisible = $state(true);
+
+  // 翻訳システム
+  const { currentLanguage } = useTranslation();
 
   // 再認証モーダル管理
   let showReauthModal = $state(false);
@@ -116,50 +129,103 @@
   }
 
   /**
-   * プロフィール統計の取得（仮実装）
+   * プロフィール統計の取得（AT Protocol API実装）
    */
   async function loadProfileStats() {
     isLoading = true;
     try {
-      // TODO: AT Protocol API で実際のプロフィール統計を取得
-      // 現在はダミーデータ
-      await new Promise(resolve => setTimeout(resolve, 500));
-      profileStats = {
-        followers: Math.floor(Math.random() * 1000) + 100,
-        following: Math.floor(Math.random() * 500) + 50,
-        posts: Math.floor(Math.random() * 2000) + 200
-      };
+      console.log('📊 [AccountCard] Loading profile stats for account:', account.profile.handle);
+      
+      // 既にキャッシュされたデータがある場合は先に表示
+      if (account.profile.followersCount !== undefined) {
+        profileStats = {
+          followers: account.profile.followersCount,
+          following: account.profile.followingCount || 0,
+          posts: account.profile.postsCount || 0
+        };
+      }
+      
+      // ProfileServiceで実際のデータを取得
+      const { profileService } = await import('$lib/services/profileService.js');
+      
+      if (!account.session?.accessJwt) {
+        console.warn('📊 [AccountCard] No access token available for profile stats');
+        return;
+      }
+      
+      const result = await profileService.getProfileStats(
+        account.profile.did,
+        account.session.accessJwt,
+        account.service
+      );
+      
+      if (result.success && result.data) {
+        profileStats = {
+          followers: result.data.followersCount,
+          following: result.data.followingCount,
+          posts: result.data.postsCount
+        };
+        
+        console.log('📊 [AccountCard] Successfully loaded profile stats:', profileStats);
+      } else {
+        // API失敗時のフォールバック表示
+        console.warn('📊 [AccountCard] Failed to load profile stats:', result.error);
+        
+        // 既存のキャッシュデータがあれば表示を維持
+        if (!profileStats && account.profile.followersCount !== undefined) {
+          profileStats = {
+            followers: account.profile.followersCount,
+            following: account.profile.followingCount || 0,
+            posts: account.profile.postsCount || 0
+          };
+        }
+      }
     } catch (error) {
-      console.error('Failed to load profile stats:', error);
+      console.error('📊 [AccountCard] Error loading profile stats:', error);
+      
+      // エラー時もキャッシュデータがあれば表示
+      if (account.profile.followersCount !== undefined) {
+        profileStats = {
+          followers: account.profile.followersCount,
+          following: account.profile.followingCount || 0,
+          posts: account.profile.postsCount || 0
+        };
+      }
     } finally {
       isLoading = false;
     }
   }
 
   /**
-   * リフレッシュトークンの期限情報を更新
+   * リフレッシュトークンの期限情報を更新（強化版）
    */
   function updateTokenExpiration() {
     try {
       if (!account.session?.refreshJwt) {
         tokenTimeRemaining = null;
+        expirationDate = null;
         return;
       }
 
+      // 残り時間を計算
       const remainingSeconds = getTokenRemainingSeconds(account.session.refreshJwt);
       tokenTimeRemaining = calculateTimeRemaining(remainingSeconds);
 
-      // 次回更新をスケジュール
+      // 絶対期限日時を取得
+      expirationDate = getTokenExpiration(account.session.refreshJwt);
+
+      // 次回更新をスケジュール（リアルタイム更新重視）
       scheduleNextUpdate();
       
     } catch (error) {
       console.warn('Failed to update token expiration:', error);
       tokenTimeRemaining = null;
+      expirationDate = null;
     }
   }
 
   /**
-   * 次回更新をスケジュール
+   * 次回更新をスケジュール（リアルタイム重視 + 省電力対応）
    */
   function scheduleNextUpdate() {
     // 既存のタイマーをクリア
@@ -168,33 +234,82 @@
       updateTimer = null;
     }
 
-    if (!tokenTimeRemaining) return;
+    if (!tokenTimeRemaining || !isPageVisible) return;
 
-    // 更新間隔を決定
-    const interval = getNextUpdateInterval(tokenTimeRemaining);
+    // 最適化された更新間隔を決定
+    const interval = getOptimalUpdateInterval(tokenTimeRemaining);
     
     updateTimer = setTimeout(() => {
-      updateTokenExpiration();
+      // ページが可視状態の場合のみ更新
+      if (isPageVisible) {
+        updateTokenExpiration();
+      } else {
+        // 非可視時は再スケジュール
+        scheduleNextUpdate();
+      }
     }, interval * 1000);
   }
 
   /**
-   * 期限表示用のテキストを生成
+   * ページ可視性の変更を処理
    */
-  function getExpirationDisplayText(timeRemaining: TimeRemaining): string {
+  function handleVisibilityChange() {
+    isPageVisible = !document.hidden;
+    
+    if (isPageVisible) {
+      // ページが表示されたら即座に更新
+      updateTokenExpiration();
+    } else {
+      // ページが非表示になったらタイマーを停止
+      if (updateTimer) {
+        clearTimeout(updateTimer);
+        updateTimer = null;
+      }
+    }
+  }
+
+  /**
+   * 期限表示用のテキストを生成（詳細版）
+   */
+  function getExpirationDisplayText(
+    timeRemaining: TimeRemaining, 
+    showDetailed: boolean = true
+  ): string {
     if (timeRemaining.isExpired) {
       return m['session.expired']();
     }
 
-    switch (timeRemaining.unit) {
-      case 'days':
-        return m['session.daysLeft']({ count: timeRemaining.value });
-      case 'hours':
-        return m['session.hoursLeft']({ count: timeRemaining.value });
-      case 'minutes':
-        return m['session.minutesLeft']({ count: timeRemaining.value });
-      default:
-        return m['session.expired']();
+    if (!showDetailed) {
+      // 簡潔版：従来の表示
+      switch (timeRemaining.unit) {
+        case 'days':
+          return m['session.daysLeft']({ count: timeRemaining.value });
+        case 'hours':
+          return m['session.hoursLeft']({ count: timeRemaining.value });
+        case 'minutes':
+          return m['session.minutesLeft']({ count: timeRemaining.value });
+        default:
+          return m['session.expired']();
+      }
+    }
+
+    // 詳細版：セッション期限 + 相対時間 + 絶対日時
+    const info = getDetailedExpirationInfo(
+      timeRemaining, 
+      expirationDate, 
+      currentLanguage(), 
+      !compact
+    );
+
+    if (compact) {
+      // コンパクト版：「約89日」
+      return `${info.aboutPrefix}${info.relativeText}`;
+    } else if (info.absoluteDate) {
+      // 標準版：「セッション期限: 約89日 (2024年9月18日まで)」
+      return `${m['session.sessionExpiry']()}: ${info.aboutPrefix}${info.relativeText} (${info.absoluteDate}${info.untilSuffix})`;
+    } else {
+      // フォールバック：「セッション期限: 約89日」
+      return `${m['session.sessionExpiry']()}: ${info.aboutPrefix}${info.relativeText}`;
     }
   }
 
@@ -244,6 +359,12 @@
     
     // リフレッシュトークンの期限情報を初期化
     updateTokenExpiration();
+    
+    // ページ可視性APIイベントリスナーを追加
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    
+    // 初期状態を設定
+    isPageVisible = !document.hidden;
   });
 
   onDestroy(() => {
@@ -252,6 +373,9 @@
       clearTimeout(updateTimer);
       updateTimer = null;
     }
+    
+    // イベントリスナーを削除
+    document.removeEventListener('visibilitychange', handleVisibilityChange);
   });
 
   // ===================================================================
@@ -326,8 +450,8 @@
             color={tokenTimeRemaining.warningLevel === 'normal' ? 'success' : 
                    tokenTimeRemaining.warningLevel === 'warning' ? 'warning' : 'error'} 
           />
-          <span class="text-xs {getWarningLevelClass(tokenTimeRemaining.warningLevel)}">
-            {getExpirationDisplayText(tokenTimeRemaining)}
+          <span class="text-xs {getWarningLevelClass(tokenTimeRemaining.warningLevel)}" title={expirationDate ? formatAbsoluteDate(expirationDate, currentLanguage(), true) : ''}>
+            {getExpirationDisplayText(tokenTimeRemaining, true)}
           </span>
         </div>
       {/if}
@@ -341,20 +465,28 @@
   </div>
 
   <!-- 統計情報（非コンパクトモード） -->
-  {#if !compact && profileStats}
-    <div class="flex justify-around pt-4 mt-4 border-t border-themed/20">
-      <div class="text-center">
-        <span class="block text-themed font-semibold text-lg">{profileStats.followers.toLocaleString()}</span>
-        <span class="block text-themed opacity-70 text-xs">{m['settings.account.followers']()}</span>
-      </div>
-      <div class="text-center">
-        <span class="block text-themed font-semibold text-lg">{profileStats.following.toLocaleString()}</span>
-        <span class="block text-themed opacity-70 text-xs">{m['settings.account.following']()}</span>
-      </div>
-      <div class="text-center">
-        <span class="block text-themed font-semibold text-lg">{profileStats.posts.toLocaleString()}</span>
-        <span class="block text-themed opacity-70 text-xs">{m['settings.account.posts']()}</span>
-      </div>
+  {#if !compact}
+    <div class="pt-4 mt-4 border-t border-themed/20">
+      {#if profileStats}
+        <div class="flex justify-around">
+          <div class="text-center">
+            <span class="block text-themed font-semibold text-lg">{profileStats.followers.toLocaleString()}</span>
+            <span class="block text-themed opacity-70 text-xs">{m['settings.account.followers']()}</span>
+          </div>
+          <div class="text-center">
+            <span class="block text-themed font-semibold text-lg">{profileStats.following.toLocaleString()}</span>
+            <span class="block text-themed opacity-70 text-xs">{m['settings.account.following']()}</span>
+          </div>
+          <div class="text-center">
+            <span class="block text-themed font-semibold text-lg">{profileStats.posts.toLocaleString()}</span>
+            <span class="block text-themed opacity-70 text-xs">{m['settings.account.posts']()}</span>
+          </div>
+        </div>
+      {:else if !isLoading}
+        <div class="text-center py-2">
+          <span class="text-themed opacity-60 text-sm">{m['settings.account.statsUnavailable']()}</span>
+        </div>
+      {/if}
     </div>
   {/if}
 

--- a/moodeSky/src/lib/deck/components/DeckContainer.svelte
+++ b/moodeSky/src/lib/deck/components/DeckContainer.svelte
@@ -382,8 +382,8 @@
     } catch (error) {
       console.error('🚨 [DeckContainer] Desktop features initialization failed:', error);
       console.error('🚨 [DeckContainer] Error details:', {
-        message: error.message,
-        stack: error.stack,
+        message: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
         elementExists: !!desktopDeckElement,
         columnsLength: deckStore.columns.length
       });
@@ -514,7 +514,7 @@
       clearInterval(stateMonitorInterval);
     }
     
-    stateMonitorInterval = setInterval(() => {
+    stateMonitorInterval = Number(setInterval(() => {
       if (swipeDetector && columnNavigator) {
         updateDebugState();
         
@@ -535,7 +535,7 @@
           updateDebugState();
         }
       }
-    }, 250); // 超高頻度での監視
+    }, 250)); // 超高頻度での監視
     
     console.log('🔍 [Monitor] State monitoring started');
   }

--- a/moodeSky/src/lib/deck/utils/swipeDetector.ts
+++ b/moodeSky/src/lib/deck/utils/swipeDetector.ts
@@ -339,8 +339,8 @@ export class CircularColumnNavigator {
       
       // 超高速フォールバック
       this.emergencyTimeouts.push(
-        setTimeout(() => this.emergencyCleanup('early'), 180),     // CSS transition完了直後
-        setTimeout(() => this.emergencyCleanup('final'), 250)      // 最終フォールバック
+        Number(setTimeout(() => this.emergencyCleanup('early'), 180)),     // CSS transition完了直後
+        Number(setTimeout(() => this.emergencyCleanup('final'), 250))      // 最終フォールバック
       );
     }
     

--- a/moodeSky/src/lib/i18n/locales/de.json
+++ b/moodeSky/src/lib/i18n/locales/de.json
@@ -131,7 +131,13 @@
     "handle": "Handle",
     "did": "DID",
     "service": "Dienst",
-    "lastAccess": "Letzter Zugriff"
+    "lastAccess": "Letzter Zugriff",
+    "stats": {
+      "loading": "Statistiken werden geladen...",
+      "error": "Fehler beim Laden der Statistiken",
+      "retry": "Wiederholen",
+      "loadingShort": "Laden..."
+    }
   },
   "login": {
     "title": "Mit Ihrem Bluesky-Konto anmelden",
@@ -176,6 +182,10 @@
   },
   "session": {
     "expiresIn": "Läuft ab in",
+    "sessionExpiry": "Sitzung läuft ab",
+    "expiresOn": "Bis: {date}",
+    "about": "~",
+    "until": "bis",
     "daysLeft": "{count} Tag(e)",
     "hoursLeft": "{count} Stunde(n)",
     "minutesLeft": "{count} Minute(n)",
@@ -314,7 +324,8 @@
       "logoutAccount": "Abmelden",
       "logoutAccountConfirm": "Von diesem Konto abmelden?",
       "logoutAccountSuccess": "Vom Konto abgemeldet",
-      "logoutAccountError": "Abmeldung fehlgeschlagen"
+      "logoutAccountError": "Abmeldung fehlgeschlagen",
+      "statsUnavailable": "Profilstatistiken nicht verfügbar"
     },
     "notifications": {
       "title": "Benachrichtigungseinstellungen",

--- a/moodeSky/src/lib/i18n/locales/en.json
+++ b/moodeSky/src/lib/i18n/locales/en.json
@@ -131,7 +131,13 @@
     "handle": "Handle",
     "did": "DID",
     "service": "Service",
-    "lastAccess": "Last Access"
+    "lastAccess": "Last Access",
+    "stats": {
+      "loading": "Loading statistics...",
+      "error": "Failed to load statistics",
+      "retry": "Retry",
+      "loadingShort": "Loading..."
+    }
   },
   "login": {
     "title": "Sign in with your Bluesky account",
@@ -176,6 +182,10 @@
   },
   "session": {
     "expiresIn": "Expires In",
+    "sessionExpiry": "Session expires",
+    "expiresOn": "Until: {date}",
+    "about": "~",
+    "until": "until",
     "daysLeft": "{count} day(s)",
     "hoursLeft": "{count} hour(s)",
     "minutesLeft": "{count} minute(s)",
@@ -314,7 +324,8 @@
       "logoutAccount": "Sign Out",
       "logoutAccountConfirm": "Log out from this account?",
       "logoutAccountSuccess": "Logged out from account",
-      "logoutAccountError": "Failed to log out"
+      "logoutAccountError": "Failed to log out",
+      "statsUnavailable": "Profile statistics unavailable"
     },
     "notifications": {
       "title": "Notification Settings",

--- a/moodeSky/src/lib/i18n/locales/ja.json
+++ b/moodeSky/src/lib/i18n/locales/ja.json
@@ -132,7 +132,13 @@
     "handle": "ハンドル",
     "did": "DID",
     "service": "サービス",
-    "lastAccess": "最終アクセス"
+    "lastAccess": "最終アクセス",
+    "stats": {
+      "loading": "統計を読み込み中...",
+      "error": "統計の取得に失敗しました",
+      "retry": "再試行",
+      "loadingShort": "読み込み中..."
+    }
   },
   "login": {
     "title": "Blueskyアカウントでログイン",
@@ -177,6 +183,10 @@
   },
   "session": {
     "expiresIn": "有効期限",
+    "sessionExpiry": "セッション期限",
+    "expiresOn": "期限: {date}",
+    "about": "約",
+    "until": "まで",
     "daysLeft": "{count}日後",
     "hoursLeft": "{count}時間後",
     "minutesLeft": "{count}分後", 
@@ -315,7 +325,8 @@
       "logoutAccount": "ログアウト",
       "logoutAccountConfirm": "このアカウントからログアウトしますか？",
       "logoutAccountSuccess": "アカウントからログアウトしました",
-      "logoutAccountError": "ログアウト処理に失敗しました"
+      "logoutAccountError": "ログアウト処理に失敗しました",
+      "statsUnavailable": "統計情報を取得できません"
     },
     "notifications": {
       "title": "通知設定", 

--- a/moodeSky/src/lib/i18n/locales/ko.json
+++ b/moodeSky/src/lib/i18n/locales/ko.json
@@ -131,7 +131,13 @@
     "handle": "핸들",
     "did": "DID",
     "service": "서비스",
-    "lastAccess": "마지막 접속"
+    "lastAccess": "마지막 접속",
+    "stats": {
+      "loading": "통계를 불러오는 중...",
+      "error": "통계 불러오기 실패",
+      "retry": "재시도",
+      "loadingShort": "불러오는 중..."
+    }
   },
   "login": {
     "title": "Bluesky 계정으로 로그인",
@@ -176,6 +182,10 @@
   },
   "session": {
     "expiresIn": "만료까지",
+    "sessionExpiry": "세션 만료",
+    "expiresOn": "기한: {date}",
+    "about": "약",
+    "until": "까지",
     "daysLeft": "{count}일",
     "hoursLeft": "{count}시간",
     "minutesLeft": "{count}분",
@@ -314,7 +324,8 @@
       "logoutAccount": "로그아웃",
       "logoutAccountConfirm": "이 계정에서 로그아웃하시겠습니까?",
       "logoutAccountSuccess": "계정에서 로그아웃했습니다",
-      "logoutAccountError": "로그아웃에 실패했습니다"
+      "logoutAccountError": "로그아웃에 실패했습니다",
+      "statsUnavailable": "프로필 통계를 사용할 수 없습니다"
     },
     "notifications": {
       "title": "알림 설정",

--- a/moodeSky/src/lib/i18n/locales/pt-BR.json
+++ b/moodeSky/src/lib/i18n/locales/pt-BR.json
@@ -131,7 +131,13 @@
     "handle": "Identificador",
     "did": "DID",
     "service": "Serviço",
-    "lastAccess": "Último acesso"
+    "lastAccess": "Último acesso",
+    "stats": {
+      "loading": "Carregando estatísticas...",
+      "error": "Falha ao carregar estatísticas",
+      "retry": "Tentar novamente",
+      "loadingShort": "Carregando..."
+    }
   },
   "login": {
     "title": "Entre com sua conta Bluesky",
@@ -176,6 +182,10 @@
   },
   "session": {
     "expiresIn": "Expira Em",
+    "sessionExpiry": "Sessão expira",
+    "expiresOn": "Até: {date}",
+    "about": "~",
+    "until": "até",
     "daysLeft": "{count} dia(s)",
     "hoursLeft": "{count} hora(s)",
     "minutesLeft": "{count} minuto(s)",
@@ -314,7 +324,8 @@
       "logoutAccount": "Sair",
       "logoutAccountConfirm": "Sair desta conta?",
       "logoutAccountSuccess": "Saiu da conta",
-      "logoutAccountError": "Falha ao sair"
+      "logoutAccountError": "Falha ao sair",
+      "statsUnavailable": "Estatísticas do perfil indisponíveis"
     },
     "notifications": {
       "title": "Configurações de Notificação",

--- a/moodeSky/src/lib/services/profileService.ts
+++ b/moodeSky/src/lib/services/profileService.ts
@@ -1,0 +1,249 @@
+/**
+ * profileService.ts
+ * AT Protocol プロフィール統計情報取得サービス
+ * 
+ * app.bsky.actor.getProfile API を使用してプロフィール統計を取得
+ * キャッシュ機能・エラーハンドリング・レート制限対応
+ */
+
+import { BskyAgent } from '@atproto/api';
+
+/**
+ * プロフィール統計情報
+ */
+export interface ProfileStats {
+  /** フォロワー数 */
+  followersCount: number;
+  /** フォロー数 */
+  followingCount: number;
+  /** ポスト数 */
+  postsCount: number;
+  /** 最終更新日時 */
+  lastUpdated: Date;
+}
+
+/**
+ * キャッシュエントリ
+ */
+interface CacheEntry {
+  stats: ProfileStats;
+  expiredAt: number;
+}
+
+/**
+ * プロフィールサービスエラー種別
+ */
+export type ProfileServiceError = 
+  | 'NETWORK_ERROR'
+  | 'RATE_LIMITED' 
+  | 'PROFILE_NOT_FOUND'
+  | 'AUTH_REQUIRED'
+  | 'INVALID_DID'
+  | 'API_ERROR';
+
+/**
+ * プロフィールサービス結果
+ */
+export interface ProfileServiceResult<T = ProfileStats> {
+  success: boolean;
+  data?: T;
+  error?: {
+    type: ProfileServiceError;
+    message: string;
+  };
+}
+
+/**
+ * AT Protocol プロフィール統計サービス
+ */
+export class ProfileService {
+  private cache = new Map<string, CacheEntry>();
+  private cacheExpiry = 5 * 60 * 1000; // 5分間キャッシュ
+  
+  /**
+   * プロフィール統計を取得
+   * @param did アカウントDID
+   * @param accessJwt アクセストークン
+   * @param service AT Protocol サービスURL
+   */
+  async getProfileStats(
+    did: string, 
+    accessJwt: string,
+    service: string = 'https://bsky.social'
+  ): Promise<ProfileServiceResult> {
+    try {
+      // DIDバリデーション
+      if (!did || !did.startsWith('did:')) {
+        return {
+          success: false,
+          error: {
+            type: 'INVALID_DID',
+            message: 'Invalid DID format'
+          }
+        };
+      }
+
+      // キャッシュチェック
+      const cached = this.getCachedStats(did);
+      if (cached) {
+        console.log(`📊 [ProfileService] Cache hit for ${did}`);
+        return {
+          success: true,
+          data: cached
+        };
+      }
+
+      // BskyAgent インスタンス作成
+      const agent = new BskyAgent({ service });
+      
+      // 認証（アクセストークンが必要）
+      if (!accessJwt) {
+        return {
+          success: false,
+          error: {
+            type: 'AUTH_REQUIRED',
+            message: 'Access token required'
+          }
+        };
+      }
+
+      // セッション復元（resumeSession を使用）
+      await agent.resumeSession({
+        accessJwt,
+        refreshJwt: '', // 統計取得には不要
+        handle: '',
+        did: did,
+        active: true
+      });
+
+      console.log(`📊 [ProfileService] Fetching profile stats for ${did}`);
+
+      // app.bsky.actor.getProfile API 呼び出し
+      const response = await agent.getProfile({ actor: did });
+      
+      if (!response.success) {
+        return {
+          success: false,
+          error: {
+            type: 'API_ERROR',
+            message: 'Failed to fetch profile'
+          }
+        };
+      }
+
+      const profile = response.data;
+      
+      // 統計情報の抽出（undefinedの場合は0として扱う）
+      const stats: ProfileStats = {
+        followersCount: profile.followersCount ?? 0,
+        followingCount: profile.followsCount ?? 0,
+        postsCount: profile.postsCount ?? 0,
+        lastUpdated: new Date()
+      };
+
+      // キャッシュに保存
+      this.setCachedStats(did, stats);
+
+      console.log(`📊 [ProfileService] Profile stats fetched:`, stats);
+
+      return {
+        success: true,
+        data: stats
+      };
+
+    } catch (error: any) {
+      console.error('📊 [ProfileService] Error fetching profile stats:', error);
+
+      // エラー種別の判定
+      let errorType: ProfileServiceError = 'API_ERROR';
+      let errorMessage = 'Unknown error occurred';
+
+      if (error.message?.includes('rate limit')) {
+        errorType = 'RATE_LIMITED';
+        errorMessage = 'Rate limit exceeded. Please try again later.';
+      } else if (error.message?.includes('network') || error.code === 'NETWORK_ERROR') {
+        errorType = 'NETWORK_ERROR';
+        errorMessage = 'Network error occurred. Please check your connection.';
+      } else if (error.status === 404 || error.message?.includes('not found')) {
+        errorType = 'PROFILE_NOT_FOUND';
+        errorMessage = 'Profile not found';
+      } else if (error.status === 401 || error.message?.includes('unauthorized')) {
+        errorType = 'AUTH_REQUIRED';
+        errorMessage = 'Authentication required';
+      }
+
+      return {
+        success: false,
+        error: {
+          type: errorType,
+          message: errorMessage
+        }
+      };
+    }
+  }
+
+  /**
+   * キャッシュから統計情報を取得
+   */
+  private getCachedStats(did: string): ProfileStats | null {
+    const entry = this.cache.get(did);
+    if (!entry) return null;
+
+    // 期限切れチェック
+    if (Date.now() > entry.expiredAt) {
+      this.cache.delete(did);
+      return null;
+    }
+
+    return entry.stats;
+  }
+
+  /**
+   * 統計情報をキャッシュに保存
+   */
+  private setCachedStats(did: string, stats: ProfileStats): void {
+    const entry: CacheEntry = {
+      stats,
+      expiredAt: Date.now() + this.cacheExpiry
+    };
+    this.cache.set(did, entry);
+  }
+
+  /**
+   * キャッシュをクリア
+   * @param did 特定のDIDをクリア（未指定時は全てクリア）
+   */
+  public clearCache(did?: string): void {
+    if (did) {
+      this.cache.delete(did);
+      console.log(`📊 [ProfileService] Cache cleared for ${did}`);
+    } else {
+      this.cache.clear();
+      console.log(`📊 [ProfileService] All cache cleared`);
+    }
+  }
+
+  /**
+   * キャッシュサイズを取得（デバッグ用）
+   */
+  public getCacheSize(): number {
+    return this.cache.size;
+  }
+
+  /**
+   * キャッシュの状態を取得（デバッグ用）
+   */
+  public getCacheInfo(): Array<{ did: string; lastUpdated: Date; expiresIn: number }> {
+    const now = Date.now();
+    return Array.from(this.cache.entries()).map(([did, entry]) => ({
+      did,
+      lastUpdated: entry.stats.lastUpdated,
+      expiresIn: Math.max(0, entry.expiredAt - now)
+    }));
+  }
+}
+
+/**
+ * プロフィールサービスインスタンス（シングルトン）
+ */
+export const profileService = new ProfileService();

--- a/moodeSky/src/lib/types/auth.ts
+++ b/moodeSky/src/lib/types/auth.ts
@@ -25,6 +25,12 @@ export interface Account {
     displayName?: string;
     /** アバター画像URL */
     avatar?: string;
+    /** フォロワー数 */
+    followersCount?: number;
+    /** フォロー数 */
+    followingCount?: number;
+    /** ポスト数 */
+    postsCount?: number;
   };
   
   /** アカウント作成日時 (ISO 8601) */
@@ -32,6 +38,20 @@ export interface Account {
   
   /** 最終アクセス日時 (ISO 8601) */
   lastAccessAt: string;
+}
+
+/**
+ * プロフィール統計情報
+ */
+export interface ProfileStats {
+  /** フォロワー数 */
+  followersCount: number;
+  /** フォロー中数 */
+  followingCount: number;
+  /** 投稿数 */
+  postsCount: number;
+  /** 最終更新日時 (ISO 8601) */
+  lastUpdated: string;
 }
 
 /**

--- a/moodeSky/src/routes/+layout.svelte
+++ b/moodeSky/src/routes/+layout.svelte
@@ -6,12 +6,60 @@
   import ThemeProvider from '../lib/components/ThemeProvider.svelte';
   // i18n初期化
   import { initializeI18n, i18nStore } from '../lib/stores/i18n.svelte.js';
+  // 認証サービス
+  import { authService } from '../lib/services/authStore.js';
+  import { accountsStore } from '../lib/stores/accounts.svelte.js';
 
   // アプリケーション初期化
   onMount(async () => {
     // i18nシステムを初期化
     await initializeI18n();
+    
+    // セッション復元・統計情報更新を実行
+    await initializeAuth();
   });
+
+  /**
+   * 認証システム初期化
+   * セッション復元と統計情報の更新を実行
+   */
+  async function initializeAuth(): Promise<void> {
+    try {
+      console.log('🔄 [App] 認証システム初期化開始...');
+      
+      // localStorage からの移行処理（初回のみ）
+      await authService.migrateFromLocalStorage();
+      
+      // 既存セッションの復元と統計情報更新
+      const refreshResult = await authService.refreshSession();
+      
+      if (refreshResult.success && Array.isArray(refreshResult.data)) {
+        const refreshedAccounts = refreshResult.data;
+        console.log(`✅ [App] ${refreshedAccounts.length}個のアカウントのセッション復元完了`);
+        
+        // accountsStoreを更新（リアクティブ反映）
+        for (const account of refreshedAccounts) {
+          await accountsStore.addAccount(account);
+        }
+        
+        // 統計情報ログ出力
+        refreshedAccounts.forEach(account => {
+          console.log(`📊 [App] ${account.profile.handle} 統計情報:`, {
+            フォロワー数: account.profile.followersCount,
+            フォロー数: account.profile.followingCount,
+            ポスト数: account.profile.postsCount,
+          });
+        });
+      } else if (!refreshResult.success) {
+        console.warn('⚠️ [App] セッション復元に失敗:', refreshResult.error);
+      } else {
+        console.log('ℹ️ [App] 復元対象のアカウントなし');
+      }
+    } catch (error) {
+      console.error('❌ [App] 認証システム初期化中にエラー:', error);
+      // 認証エラーはアプリ全体を停止させない
+    }
+  }
 </script>
 
 <!-- テーマプロバイダーでアプリ全体をラップ -->

--- a/moodeSky/src/routes/login/+page.svelte
+++ b/moodeSky/src/routes/login/+page.svelte
@@ -50,24 +50,21 @@
       // ログイン成功 - didとハンドル、プロフィール情報を保存
       console.log('ログイン成功:', response);
       
-      // プロフィール情報を取得
-      const profile = await agent.getProfile({ actor: response.data.did });
-      console.log('プロフィール情報:', profile.data);
-      
-      // Store API に認証情報を保存
+      // Store API に認証情報を保存（統計情報も自動取得・保存）
       const sessionData = {
         ...response.data,
         active: response.data.active ?? true  // activeがundefinedの場合はtrueを設定
       };
       
+      // saveAccountが内部でプロフィール情報と統計情報を自動取得するため、
+      // 基本情報のみ渡す（統計情報は自動取得される）
       const saveResult = await authService.saveAccount(
         `https://${host}`,
         sessionData,
         {
           did: response.data.did,
           handle: response.data.handle,
-          displayName: profile.data.displayName,
-          avatar: profile.data.avatar,
+          // displayNameとavatarは自動取得される
         }
       );
       
@@ -78,6 +75,11 @@
       }
       
       console.log('認証情報を正常に保存:', saveResult.data);
+      console.log('📊 プロフィール統計情報:', {
+        フォロワー数: saveResult.data?.profile.followersCount,
+        フォロー数: saveResult.data?.profile.followingCount,
+        ポスト数: saveResult.data?.profile.postsCount,
+      });
       
       // アカウントストアにも追加（リアクティブ更新）
       if (saveResult.data) {


### PR DESCRIPTION
## Summary
- セッション期限表示を「約89日」から「セッション期限: 約89日 (2024年9月18日まで)」形式に改善
- 5言語対応の翻訳キーを追加し、リアルタイム更新機能を実装
- Page Visibility API統合による省電力最適化
- プロフィール統計API統合とエラーハンドリング強化

## 主な変更内容

### 🌍 多言語翻訳追加
- **対象ファイル**: `src/lib/i18n/locales/*.json` (ja, en, pt-BR, de, ko)
- **新規翻訳キー**: `session.sessionExpiry`, `session.about`, `session.until`, `session.expiresOn`
- **プロフィール統計**: `profile.stats.*`, `settings.account.statsUnavailable`

### ⏰ 時間計算・表示機能強化
- **対象ファイル**: `src/lib/utils/timeUtils.ts`
- **新機能**: `formatAbsoluteDate()` - 多言語絶対日時フォーマット
- **新機能**: `getDetailedExpirationInfo()` - 詳細期限情報生成
- **最適化**: `getOptimalUpdateInterval()` - リアルタイム更新間隔調整

### 🎯 AccountCard.svelte セッション表示改善
- **期限表示形式**: 「セッション期限: 約89日 (2024年9月18日まで)」
- **ツールチップ**: 絶対日時の詳細表示 (時刻付き)
- **リアルタイム更新**: Page Visibility API統合による省電力動作
- **プロフィール統計**: AT Protocol API統合による実データ表示

### 🚀 パフォーマンス最適化
- **更新間隔調整**: 7日以上→1時間、未満→30分、6時間未満→2分
- **省電力対応**: ページ非表示時の更新停止
- **フォールバック**: 統計API失敗時のキャッシュデータ活用

## 技術的詳細

### セッション期限計算フロー
1. **JWT解析**: `exp`クレーム（Unix timestamp）取得
2. **時間計算**: 現在時刻との差分計算
3. **表示単位決定**: 日・時・分の適切な単位選択
4. **多言語対応**: 言語別プレフィックス・サフィックス適用

### リアルタイム更新システム
```typescript
// 最適化された更新間隔
switch (timeRemaining.unit) {
  case 'days': return timeRemaining.value >= 7 ? 3600 : 1800;  // 1時間 or 30分
  case 'hours': return timeRemaining.value >= 6 ? 300 : 120;   // 5分 or 2分  
  case 'minutes': return 60;  // 1分間隔
}
```

### プロフィール統計API統合
- **自動取得**: アカウント保存時の統計情報自動取得
- **キャッシュ活用**: API失敗時の既存データ表示継続
- **エラーハンドリング**: 統計取得失敗が基本認証をブロックしない設計

## Test plan
- [ ] 全5言語でのセッション期限表示確認
- [ ] リアルタイム更新動作テスト（Page Visibility切替）
- [ ] プロフィール統計表示確認（API成功・失敗両パターン）
- [ ] 異なる期限残時間での表示・更新間隔確認
- [ ] モバイルデバイスでの省電力動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)