### PR TITLE
UX: デッキカラム間隔の最適化 - タイトなレイアウトの実現

### DIFF
--- a/moodeSky/src/lib/deck/components/DeckContainer.svelte
+++ b/moodeSky/src/lib/deck/components/DeckContainer.svelte
@@ -943,6 +943,7 @@
     display: flex;
     flex-direction: column;
     margin-left: 0; /* 全カラムで左マージンなし - タイトなレイアウト */
+    margin-right: 8px; /* 全カラムで右余白8px */
   }
   
   .deck-column-mobile-wrapper {

--- a/moodeSky/src/lib/deck/components/DeckContainer.svelte
+++ b/moodeSky/src/lib/deck/components/DeckContainer.svelte
@@ -942,12 +942,7 @@
     height: 100%; /* 親コンテナの高さに合わせる */
     display: flex;
     flex-direction: column;
-    margin-left: var(--deck-gap, 16px); /* 2つ目以降のカラムに左マージン */
-  }
-
-  /* 最初のカラムは左マージンなし */
-  .deck-column-wrapper:first-child {
-    margin-left: 0;
+    margin-left: 0; /* 全カラムで左マージンなし - タイトなレイアウト */
   }
   
   .deck-column-mobile-wrapper {

--- a/moodeSky/src/lib/deck/components/DeckContainer.svelte
+++ b/moodeSky/src/lib/deck/components/DeckContainer.svelte
@@ -899,7 +899,6 @@
     overflow-x: auto;
     overflow-y: hidden;
     padding: 8px !important; /* 全方向8px均等（上右下左） - デスクトップ最適化（CSS変数より優先） */
-    gap: var(--deck-gap, 16px);
     scroll-behavior: smooth;
     display: flex;
     align-items: stretch; /* 子要素の高さを確実に揃える */
@@ -943,6 +942,12 @@
     height: 100%; /* 親コンテナの高さに合わせる */
     display: flex;
     flex-direction: column;
+    margin-left: var(--deck-gap, 16px); /* 2つ目以降のカラムに左マージン */
+  }
+
+  /* 最初のカラムは左マージンなし */
+  .deck-column-wrapper:first-child {
+    margin-left: 0;
   }
   
   .deck-column-mobile-wrapper {


### PR DESCRIPTION
## Summary
デッキカラム間の間隔を最適化し、よりタイトで効率的なレイアウトを実現

### 変更内容
- **flexbox gapからmarginシステムへ変更**: より細かい制御が可能
- **左マージン除去**: 全カラムで`margin-left: 0`に設定
- **統一右余白**: 全カラムに`margin-right: 8px`を適用

### レイアウト変更
**Before**: `左8px | column1 | 16px | column2 | 16px | column3 | 8px右`
**After**: `左8px | column1 | 8px | column2 | 8px | column3 | 8px | 8px右`

### 技術的改善
- CSS flexbox `gap`プロパティの削除
- 個別margin制御による柔軟なレイアウト
- 既存のCSS変数`--deck-gap`との完全な分離

## Test plan
- [x] TypeScript型チェック通過確認
- [x] 本番ビルド成功確認
- [x] デスクトップレイアウトでの表示確認
- [x] 複数カラム表示での間隔確認

## Impact
- **UX向上**: より密度の高い効率的なデッキ表示
- **視覚的改善**: 統一された8px間隔による整然としたレイアウト
- **後方互換性**: 既存機能への影響なし

🤖 Generated with [Claude Code](https://claude.ai/code)