### PR TITLE
Fix: テーマ色一貫性・視認性・プレビュー正確性の向上

### DIFF
--- a/moodeSky/src/app.css
+++ b/moodeSky/src/app.css
@@ -172,9 +172,9 @@
     outline: 2px solid rgb(var(--accent)) !important;
   }
 
-  /* ハイコントラスト時のhover/focus状態での全子要素色修正 */
-  .high-contrast button:hover *,
-  .high-contrast button:focus *,
+  /* ハイコントラスト時のhover/focus状態での全子要素色修正 (プレビューテキスト除く) */
+  .high-contrast button:hover *:not(.preview-text),
+  .high-contrast button:focus *:not(.preview-text),
   .high-contrast button:hover svg,
   .high-contrast button:focus svg {
     color: rgb(var(--background)) !important;
@@ -187,6 +187,12 @@
   .high-contrast button:hover .text-muted,
   .high-contrast button:focus .text-muted {
     color: rgb(var(--background)) !important;
+  }
+
+  /* テーマプレビューテキストの保護 - CSS変数で確実に固定 */
+  .high-contrast button:hover .preview-text,
+  .high-contrast button:focus .preview-text {
+    color: var(--preview-color) !important;
   }
 
 

--- a/moodeSky/src/lib/components/SideNavigation.svelte
+++ b/moodeSky/src/lib/components/SideNavigation.svelte
@@ -126,7 +126,7 @@
         color="themed"
         ariaLabel={t('navigation.compose')}
         decorative={true}
-        class="text-white"
+        class="!text-[var(--color-background)]"
       />
       <span>{t('navigation.post')}</span>
     </button>
@@ -244,7 +244,7 @@
   .side-navigation__compose-button {
     width: 100%;
     background-color: rgb(var(--primary));
-    color: white;
+    color: var(--color-background);
     font-weight: 600;
     padding: 1rem 1.5rem;
     border-radius: 0.75rem;

--- a/moodeSky/src/lib/components/ToggleSwitch.svelte
+++ b/moodeSky/src/lib/components/ToggleSwitch.svelte
@@ -107,7 +107,9 @@
     >
       <!-- サム（丸い部分） -->
       <div 
-        class="{config.thumb} bg-white rounded-full shadow-md transition-all duration-300 absolute {config.top}"
+        class="{config.thumb} rounded-full shadow-md transition-all duration-300 absolute {config.top}"
+        class:bg-white={!checked}
+        class:bg-[var(--color-background)]={checked}
         class:shadow-lg={checked}
         style="transform: translateX({thumbPosition()}px);"
       ></div>

--- a/moodeSky/src/routes/settings/+page.svelte
+++ b/moodeSky/src/routes/settings/+page.svelte
@@ -97,7 +97,7 @@
       <h2 class="text-error text-2xl font-semibold mb-4">{t('common.error')}</h2>
       <p class="text-error mb-8">{errorMessage}</p>
       <button 
-        class="bg-error hover:bg-error/80 text-white font-semibold py-3 px-6 rounded-lg transition-colors"
+        class="bg-error hover:bg-error/80 text-[var(--color-background)] font-semibold py-3 px-6 rounded-lg transition-colors"
         onclick={() => location.reload()}
       >
         {t('common.retry')}
@@ -128,34 +128,34 @@
             <button
               class="px-4 py-2 rounded-md text-sm font-medium transition-colors flex items-center gap-2"
               class:bg-primary={activeSection === 'theme'}
-              class:text-white={activeSection === 'theme'}
+              class:text-[var(--color-background)]={activeSection === 'theme'}
               class:text-themed={activeSection !== 'theme'}
               class:hover:bg-muted={activeSection !== 'theme'}
               onclick={() => switchSection('theme')}
             >
-              <Icon icon={ICONS.PALETTE} size="sm" color={activeSection === 'theme' ? 'white' : 'themed'} />
+              <Icon icon={ICONS.PALETTE} size="sm" class={activeSection === 'theme' ? '!text-[var(--color-background)]' : 'text-themed'} />
               {t('settings.tabs.theme')}
             </button>
             <button
               class="px-4 py-2 rounded-md text-sm font-medium transition-colors flex items-center gap-2"
               class:bg-primary={activeSection === 'language'}
-              class:text-white={activeSection === 'language'}
+              class:text-[var(--color-background)]={activeSection === 'language'}
               class:text-themed={activeSection !== 'language'}
               class:hover:bg-muted={activeSection !== 'language'}
               onclick={() => switchSection('language')}
             >
-              <Icon icon={ICONS.LANGUAGE} size="sm" color={activeSection === 'language' ? 'white' : 'themed'} />
+              <Icon icon={ICONS.LANGUAGE} size="sm" class={activeSection === 'language' ? '!text-[var(--color-background)]' : 'text-themed'} />
               {t('settings.tabs.language')}
             </button>
             <button
               class="px-4 py-2 rounded-md text-sm font-medium transition-colors flex items-center gap-2"
               class:bg-primary={activeSection === 'account'}
-              class:text-white={activeSection === 'account'}
+              class:text-[var(--color-background)]={activeSection === 'account'}
               class:text-themed={activeSection !== 'account'}
               class:hover:bg-muted={activeSection !== 'account'}
               onclick={() => switchSection('account')}
             >
-              <Icon icon={ICONS.PERSON} size="sm" color={activeSection === 'account' ? 'white' : 'themed'} />
+              <Icon icon={ICONS.PERSON} size="sm" class={activeSection === 'account' ? '!text-[var(--color-background)]' : 'text-themed'} />
               {t('settings.tabs.account')}
             </button>
             <button

--- a/moodeSky/src/routes/settings/components/AccountSettings.svelte
+++ b/moodeSky/src/routes/settings/components/AccountSettings.svelte
@@ -238,7 +238,7 @@
             disabled={isLoading || isMaxAccountsReached()}
             onclick={addAccount}
           >
-            <Icon icon={ICONS.ADD} size="sm" color="white" />
+            <Icon icon={ICONS.ADD} size="sm" color="themed" class="!text-[var(--color-background)]" />
             {m['settings.account.addAccount']()}
           </button>
         </div>
@@ -370,7 +370,7 @@
             {m['common.cancel']()}
           </button>
           <button
-            class="px-4 py-2 bg-error text-white rounded-lg hover:bg-error/80 transition-colors"
+            class="px-4 py-2 bg-error text-[var(--color-background)] rounded-lg hover:bg-error/80 transition-colors"
             onclick={logoutAll}
             disabled={isLoading}
           >

--- a/moodeSky/src/routes/settings/components/LanguageSettings.svelte
+++ b/moodeSky/src/routes/settings/components/LanguageSettings.svelte
@@ -293,7 +293,7 @@
             disabled={isLoading || i18nStore.currentLanguage === i18nStore.systemLanguage}
             onclick={handleResetToSystemLanguage}
           >
-            <Icon icon={ICONS.COMPUTER} size="sm" color="white" />
+            <Icon icon={ICONS.COMPUTER} size="sm" color="themed" class="!text-[var(--color-background)]" />
             {m['settings.language.resetToSystem']()}
           </button>
         </div>

--- a/moodeSky/src/routes/settings/components/ThemeSettings.svelte
+++ b/moodeSky/src/routes/settings/components/ThemeSettings.svelte
@@ -21,6 +21,56 @@
   let successMessage = $state('');
   let errorMessage = $state('');
 
+  // ===================================================================
+  // システム色設定検出
+  // ===================================================================
+
+  // システムがダークモードかどうかを検出
+  let isSystemDarkMode = $state(false);
+
+  // システム色設定の初期化と監視
+  $effect(() => {
+    if (typeof window !== 'undefined') {
+      const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+      isSystemDarkMode = mediaQuery.matches;
+      
+      const handleChange = (e: MediaQueryListEvent) => {
+        isSystemDarkMode = e.matches;
+      };
+      
+      mediaQuery.addEventListener('change', handleChange);
+      
+      return () => {
+        mediaQuery.removeEventListener('change', handleChange);
+      };
+    }
+  });
+
+  // システムテーマのプレビュー色を動的に決定
+  const systemPreview = $derived(() => {
+    if (isSystemDarkMode) {
+      // システムがダークモード -> ダークテーマの色
+      return {
+        background: 'from-[#0f172a] to-[#0c1220]',
+        surface: 'bg-[#0f172a] border-slate-500',
+        text: 'text-slate-100',
+        accent: 'bg-orange-400'
+      };
+    } else {
+      // システムがライトモード -> ライトテーマの色
+      return {
+        background: 'from-blue-50 to-blue-100',
+        surface: 'bg-white border-gray-200',
+        text: 'text-slate-900',
+        accent: 'bg-blue-500'
+      };
+    }
+  });
+
+  // ===================================================================
+  // テーマオプション定義
+  // ===================================================================
+
   // テーマオプション定義（ThemeToggleと同じ構造）
   // $derivedを使用してリアクティブに言語切り替えに対応
   const themeOptions = $derived<Array<{
@@ -40,12 +90,7 @@
       label: m['settings.theme.systemTheme'](),
       icon: ICONS.COMPUTER,
       description: m['settings.theme.systemDescription'](),
-      preview: {
-        background: 'bg-gradient-themed',
-        surface: 'bg-card border-themed',
-        text: 'text-themed',
-        accent: 'text-primary'
-      }
+      preview: systemPreview()
     },
     {
       mode: 'light',
@@ -53,10 +98,10 @@
       icon: ICONS.LIGHT_MODE,
       description: m['settings.theme.lightDescription'](),
       preview: {
-        background: 'bg-gradient-primary',
-        surface: 'bg-card border-themed',
-        text: 'text-themed',
-        accent: 'text-primary'
+        background: 'from-blue-50 to-blue-100',
+        surface: 'bg-white border-gray-200',
+        text: 'text-slate-900',
+        accent: 'bg-blue-500'
       }
     },
     {
@@ -65,10 +110,10 @@
       icon: ICONS.DARK_MODE,
       description: m['settings.theme.darkDescription'](),
       preview: {
-        background: 'bg-gradient-themed',
-        surface: 'bg-card border-themed',
-        text: 'text-themed',
-        accent: 'text-primary'
+        background: 'from-[#0f172a] to-[#0c1220]',
+        surface: 'bg-[#0f172a] border-slate-500',
+        text: 'text-slate-100',
+        accent: 'bg-orange-400'
       }
     },
     {
@@ -77,10 +122,10 @@
       icon: ICONS.CONTRAST,
       description: m['settings.theme.highContrastDescription'](),
       preview: {
-        background: 'bg-gradient-themed',
-        surface: 'bg-card border-themed border-2',
-        text: 'text-themed',
-        accent: 'text-primary'
+        background: 'from-black to-gray-900',
+        surface: 'bg-black border-white border-2',
+        text: 'text-white',
+        accent: 'bg-yellow-400'
       }
     }
   ]);
@@ -245,9 +290,6 @@
             disabled={isLoading}
             onclick={() => handleThemeChange(option.mode)}
           >
-            <!-- プレビュー背景 -->
-            <div class="absolute inset-0 bg-gradient-to-br opacity-10 {option.preview.background}"></div>
-            
             <!-- コンテンツ -->
             <div class="relative z-10">
               <div class="flex items-center justify-between mb-3">

--- a/moodeSky/src/routes/settings/components/ThemeSettings.svelte
+++ b/moodeSky/src/routes/settings/components/ThemeSettings.svelte
@@ -54,6 +54,7 @@
         background: 'from-[#0f172a] to-[#0c1220]',
         surface: 'bg-[#0f172a] border-slate-500',
         text: 'text-slate-100',
+        textColor: '#f1f5f9',  // slate-100の実際の色値
         accent: 'bg-orange-400'
       };
     } else {
@@ -62,6 +63,7 @@
         background: 'from-blue-50 to-blue-100',
         surface: 'bg-white border-gray-200',
         text: 'text-slate-900',
+        textColor: '#0f172a',  // slate-900の実際の色値
         accent: 'bg-blue-500'
       };
     }
@@ -82,6 +84,7 @@
       background: string;
       surface: string;
       text: string;
+      textColor: string;
       accent: string;
     };
   }>>([
@@ -101,6 +104,7 @@
         background: 'from-blue-50 to-blue-100',
         surface: 'bg-white border-gray-200',
         text: 'text-slate-900',
+        textColor: '#0f172a',  // slate-900
         accent: 'bg-blue-500'
       }
     },
@@ -113,6 +117,7 @@
         background: 'from-[#0f172a] to-[#0c1220]',
         surface: 'bg-[#0f172a] border-slate-500',
         text: 'text-slate-100',
+        textColor: '#f1f5f9',  // slate-100
         accent: 'bg-orange-400'
       }
     },
@@ -125,6 +130,7 @@
         background: 'from-black to-gray-900',
         surface: 'bg-black border-white border-2',
         text: 'text-white',
+        textColor: '#ffffff',  // white
         accent: 'bg-yellow-400'
       }
     }
@@ -313,12 +319,12 @@
               
               <!-- プレビューカード -->
               <div class="rounded border p-2 {option.preview.surface}">
-                <div class="text-xs {option.preview.text}">
+                <div class="text-xs">
                   <div class="flex items-center gap-2 mb-1">
                     <div class="w-2 h-2 rounded-full {option.preview.accent}"></div>
-                    <span class="font-medium">{m['settings.theme.sampleText']()}</span>
+                    <span class="font-medium preview-text" style="--preview-color: {option.preview.textColor}; color: var(--preview-color)">{m['settings.theme.sampleText']()}</span>
                   </div>
-                  <div class="opacity-70">{option.description}</div>
+                  <div class="preview-text" style="--preview-color: {option.preview.textColor}; color: var(--preview-color); opacity: 0.7">{option.description}</div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- ダークテーマでのオレンジ背景ボタンの白固定色問題を修正
- トグルスイッチの視認性を改善
- テーマプレビューの色表示を各テーマの実際の色に修正

## Changes Made

### 🎨 テーマ色一貫性の修正
- **投稿ボタン**: `color: white` → `color: var(--color-background)` 
- **設定タブボタン**: 白固定 → テーマ対応背景色
- **アカウント管理ボタン**: 白固定アイコン → テーマ対応
- **言語設定ボタン**: 白固定アイコン → テーマ対応

### 🔘 トグルスイッチ視認性改善
- **オフ状態**: 白色の円（全テーマで視認可能）
- **オン状態**: テーマ背景色の円（一貫性維持）
- **ダークテーマ**: オフ時の視認性大幅向上

### 🖼️ テーマプレビュー正確性向上
- **ライトテーマボタン**: 常に白背景+青アクセント表示
- **ダークテーマボタン**: 常に `#0f172a` 背景+オレンジアクセント表示
- **ハイコントラストボタン**: 常に黒背景+黄色アクセント表示
- **システムテーマボタン**: OS設定に応じて動的表示（ライト/ダーク）

### 🔧 技術改善
- CSS Variables活用による統一テーマシステム
- `\!important` 修飾子による確実なアイコン色制御
- MediaQuery使用によるシステム色設定動的検出
- プレビュー背景重複解消による視認性向上

## Test Plan
- [x] 全テーマでボタン・アイコン色の正確性確認
- [x] トグルスイッチのオン/オフ視認性確認
- [x] テーマプレビューの色正確性確認
- [x] システムテーマの動的表示確認
- [x] TypeScript 0エラー確認

🤖 Generated with [Claude Code](https://claude.ai/code)