### PR TITLE
🐛 Fix mobile modal layout inconsistency in deck add flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,6 +358,30 @@ const navItems = $derived<NavItem[]>([
 ]);
 ```
 
+### 5. AT Protocol Identification Pattern
+**Critical Rule: Always use DID for reliable identification**
+
+**Identification Hierarchy (by reliability):**
+1. **DID (Decentralized Identifier)**: **IMMUTABLE** - Never changes, highest reliability
+2. **Handle**: **VARIABLE** - Can change, lower reliability for persistent identification
+
+```typescript
+// ✅ Good: Use DID for persistent identification, caching, and database keys
+const cachedProfile = avatarCache.get(account.profile.did);
+const accountLookup = accounts.find(acc => acc.profile.did === targetDid);
+
+// ⚠️ Acceptable: Use handle for display and user-facing features only
+const displayText = `@${account.profile.handle}`;
+const userFriendlyId = account.profile.handle;
+
+// ❌ Bad: Using handle for persistent identification or caching
+const cachedProfile = cache.get(account.profile.handle); // Handle can change!
+```
+
+**Key Use Cases:**
+- **DID**: Database keys, caching, persistent references, account matching
+- **Handle**: User display, @mentions, user-friendly URLs, temporary lookups
+
 ## Important Files & Configurations
 
 ### Critical Files to Monitor

--- a/moodeSky/src-tauri/Cargo.lock
+++ b/moodeSky/src-tauri/Cargo.lock
@@ -69,6 +69,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "ashpd"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cbdf310d77fd3aaee6ea2093db7011dc2d35d2eb3481e5607f1f8d942ed99df"
+dependencies = [
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand 0.9.1",
+ "raw-window-handle",
+ "serde",
+ "serde_repr",
+ "tokio",
+ "url",
+ "zbus",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "7.0.0"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
+checksum = "9991eea70ea4f293524138648e41ee89b0b2b12ddef3b255effa43c8056e0e0d"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -346,9 +364,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "4.0.3"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a334ef7c9e23abf0ce748e8cd309037da93e606ad52eb372e4ce327a0dcfbdfd"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -659,15 +677,15 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
-version = "0.27.2"
+version = "0.29.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "754b69d351cdc2d8ee09ae203db831e005560fc6030da058f86ad60c92a9cb0a"
+checksum = "f93d03419cb5950ccfd3daf3ff1c7a36ace64609a1a8746d493df1ca0afde0fa"
 dependencies = [
  "cssparser-macros",
  "dtoa-short",
- "itoa 0.4.8",
+ "itoa",
  "matches",
- "phf 0.8.0",
+ "phf 0.10.1",
  "proc-macro2",
  "quote",
  "smallvec",
@@ -801,6 +819,18 @@ name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
+
+[[package]]
+name = "dispatch2"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a0d569e003ff27784e0e14e4a594048698e0c0f0b66cabcb51511be55a7caa0"
+dependencies = [
+ "bitflags 2.9.1",
+ "block2 0.6.1",
+ "libc",
+ "objc2 0.6.1",
+]
 
 [[package]]
 name = "dispatch2"
@@ -1598,16 +1628,14 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.26.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bea68cab48b8459f17cf1c944c67ddc572d272d9f2b274140f223ecb1da4a3b7"
+checksum = "3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c"
 dependencies = [
  "log",
  "mac",
  "markup5ever",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "match_token",
 ]
 
 [[package]]
@@ -1618,7 +1646,7 @@ checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.15",
+ "itoa",
 ]
 
 [[package]]
@@ -1662,7 +1690,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
- "itoa 1.0.15",
+ "itoa",
  "pin-project-lite",
  "smallvec",
  "tokio",
@@ -1908,12 +1936,6 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
-
-[[package]]
-name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
@@ -2008,14 +2030,13 @@ dependencies = [
 
 [[package]]
 name = "kuchikiki"
-version = "0.8.2"
+version = "0.8.8-speedreader"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e4755b7b995046f510a7520c42b2fed58b77bd94d5a87a8eb43d2fd126da8"
+checksum = "02cb977175687f33fa4afa0c95c112b987ea1443e5a51c8f8ff27dc618270cc2"
 dependencies = [
  "cssparser",
  "html5ever",
- "indexmap 1.9.3",
- "matches",
+ "indexmap 2.9.0",
  "selectors",
 ]
 
@@ -2131,16 +2152,27 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "markup5ever"
-version = "0.11.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2629bb1404f3d34c2e921f21fd34ba00b206124c81f65c50b43b6aaefeb016"
+checksum = "c7a7213d12e1864c0f002f52c2923d4556935a43dec5e71355c2760e0f6e7a18"
 dependencies = [
  "log",
- "phf 0.10.1",
- "phf_codegen 0.10.0",
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
  "string_cache",
  "string_cache_codegen",
  "tendril",
+]
+
+[[package]]
+name = "match_token"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2209,6 +2241,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
  "tauri-plugin-opener",
  "tauri-plugin-os",
  "tauri-plugin-sql",
@@ -2439,7 +2472,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
 dependencies = [
  "bitflags 2.9.1",
- "dispatch2",
+ "dispatch2 0.3.0",
  "objc2 0.6.1",
 ]
 
@@ -2450,7 +2483,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "989c6c68c13021b5c2d6b71456ebb0f9dc78d752e86a98da7c716f4f9470f5a4"
 dependencies = [
  "bitflags 2.9.1",
- "dispatch2",
+ "dispatch2 0.3.0",
  "objc2 0.6.1",
  "objc2-core-foundation",
  "objc2-io-surface",
@@ -2715,9 +2748,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12"
 dependencies = [
- "phf_macros 0.8.0",
  "phf_shared 0.8.0",
- "proc-macro-hack",
 ]
 
 [[package]]
@@ -2726,7 +2757,9 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
 dependencies = [
+ "phf_macros 0.10.0",
  "phf_shared 0.10.0",
+ "proc-macro-hack",
 ]
 
 [[package]]
@@ -2751,12 +2784,12 @@ dependencies = [
 
 [[package]]
 name = "phf_codegen"
-version = "0.10.0"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
- "phf_generator 0.10.0",
- "phf_shared 0.10.0",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -2791,12 +2824,12 @@ dependencies = [
 
 [[package]]
 name = "phf_macros"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6fde18ff429ffc8fe78e2bf7f8b7a5a5a6e2a8b58bc5a9ac69198bbda9189c"
+checksum = "58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0"
 dependencies = [
- "phf_generator 0.8.0",
- "phf_shared 0.8.0",
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
  "proc-macro-hack",
  "proc-macro2",
  "quote",
@@ -3081,6 +3114,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3101,6 +3144,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3116,6 +3169,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -3247,6 +3309,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80c844748fdc82aae252ee4594a89b6e7ebef1063de7951545564cbc4e57075d"
+dependencies = [
+ "ashpd",
+ "block2 0.6.1",
+ "dispatch2 0.2.0",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2 0.6.1",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.1",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3362,22 +3449,20 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "selectors"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df320f1889ac4ba6bc0cdc9c9af7af4bd64bb927bccdf32d81140dc1f9be12fe"
+checksum = "0c37578180969d00692904465fb7f6b3d50b9a2b952b87c23d0e2e5cb5013416"
 dependencies = [
  "bitflags 1.3.2",
  "cssparser",
  "derive_more",
  "fxhash",
  "log",
- "matches",
  "phf 0.8.0",
  "phf_codegen 0.8.0",
  "precomputed-hash",
  "servo_arc",
  "smallvec",
- "thin-slice",
 ]
 
 [[package]]
@@ -3437,7 +3522,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
- "itoa 1.0.15",
+ "itoa",
  "memchr",
  "ryu",
  "serde",
@@ -3470,7 +3555,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.15",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -3530,9 +3615,9 @@ dependencies = [
 
 [[package]]
 name = "servo_arc"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98238b800e0d1576d8b6e3de32827c2d74bee68bb97748dcf5071fb53965432"
+checksum = "d52aa42f8fdf0fed91e5ce7f23d8138441002fa31dca008acf47e6fd4721f741"
 dependencies = [
  "nodrop",
  "stable_deref_trait",
@@ -3804,7 +3889,7 @@ dependencies = [
  "hex",
  "hkdf",
  "hmac",
- "itoa 1.0.15",
+ "itoa",
  "log",
  "md-5",
  "memchr",
@@ -3844,7 +3929,7 @@ dependencies = [
  "hkdf",
  "hmac",
  "home",
- "itoa 1.0.15",
+ "itoa",
  "log",
  "md-5",
  "memchr",
@@ -4024,9 +4109,9 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e59c1f38e657351a2e822eadf40d6a2ad4627b9c25557bc1180ec1b3295ef82"
+checksum = "49c380ca75a231b87b6c9dd86948f035012e7171d1a7c40a9c2890489a7ffd8a"
 dependencies = [
  "bitflags 2.9.1",
  "core-foundation",
@@ -4080,16 +4165,15 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "2.5.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7b0bc1aec81bda6bc455ea98fcaed26b3c98c1648c627ad6ff1c704e8bf8cbc"
+checksum = "2f7a0f4019c80391d143ee26cd7cd1ed271ac241d3087d333f99f3269ba90812"
 dependencies = [
  "anyhow",
  "bytes",
  "dirs",
  "dunce",
  "embed_plist",
- "futures-util",
  "getrandom 0.2.16",
  "glob",
  "gtk",
@@ -4131,9 +4215,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a0350f0df1db385ca5c02888a83e0e66655c245b7443db8b78a70da7d7f8fc"
+checksum = "12f025c389d3adb83114bec704da973142e82fc6ec799c7c750c5e21cefaec83"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -4153,9 +4237,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-codegen"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93f035551bf7b11b3f51ad9bc231ebbe5e085565527991c16cf326aa38cdf47"
+checksum = "f5df493a1075a241065bc865ed5ef8d0fbc1e76c7afdc0bf0eccfaa7d4f0e406"
 dependencies = [
  "base64 0.22.1",
  "brotli",
@@ -4180,9 +4264,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8db4df25e2d9d45de0c4c910da61cd5500190da14ae4830749fee3466dddd112"
+checksum = "1f59e1d1fa9651212dcb890a0c66226d819b716490b0cf43c078514da3591705"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -4194,9 +4278,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a5ebe6a610d1b78a94650896e6f7c9796323f408800cef436e0fa0539de601"
+checksum = "1d9a0bd00bf1930ad1a604d08b0eb6b2a9c1822686d65d7f4731a7723b8901d3"
 dependencies = [
  "anyhow",
  "glob",
@@ -4207,6 +4291,46 @@ dependencies = [
  "tauri-utils",
  "toml",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aefb14219b492afb30b12647b5b1247cadd2c0603467310c36e0f7ae1698c28"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.12",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c341290d31991dbca38b31d412c73dfbdb070bb11536784f19dd2211d13b778f"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.12",
+ "toml",
+ "url",
 ]
 
 [[package]]
@@ -4286,9 +4410,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00f004905d549854069e6774533d742b03cacfd6f03deb08940a8677586cbe39"
+checksum = "9e7bb73d1bceac06c20b3f755b2c8a2cb13b20b50083084a8cf3700daf397ba4"
 dependencies = [
  "cookie",
  "dpi",
@@ -4308,9 +4432,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f85d056f4d4b014fe874814034f3416d57114b617a493a4fe552580851a3f3a2"
+checksum = "fe52ed0ef40fd7ad51a620ecb3018e32eba3040bb95025216a962a37f6f050c5"
 dependencies = [
  "gtk",
  "http",
@@ -4335,9 +4459,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2900399c239a471bcff7f15c4399eb1a8c4fe511ba2853e07c996d771a5e0a4"
+checksum = "41743bbbeb96c3a100d234e5a0b60a46d5aa068f266160862c7afdbf828ca02e"
 dependencies = [
  "anyhow",
  "brotli",
@@ -4407,12 +4531,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thin-slice"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaa81235c7058867fa8c0e7314f33dcce9c215f535d1913822a2b3f5e289f3c"
-
-[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4459,7 +4577,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
- "itoa 1.0.15",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde",
@@ -4519,8 +4637,10 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.52.0",
 ]
 
@@ -5096,9 +5216,9 @@ dependencies = [
 
 [[package]]
 name = "webview2-com"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b542b5cfbd9618c46c2784e4d41ba218c336ac70d44c55e47b251033e7d85601"
+checksum = "d4ba622a989277ef3886dd5afb3e280e3dd6d974b766118950a08f8f678ad6a4"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
@@ -5121,9 +5241,9 @@ dependencies = [
 
 [[package]]
 name = "webview2-com-sys"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae2d11c4a686e4409659d7891791254cf9286d3cfe0eef54df1523533d22295"
+checksum = "36695906a1b53a3bf5c4289621efedac12b73eeb0b89e7e1a89b517302d5d75c"
 dependencies = [
  "thiserror 2.0.12",
  "windows",
@@ -5638,9 +5758,9 @@ checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "wry"
-version = "0.51.2"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c886a0a9d2a94fd90cfa1d929629b79cfefb1546e2c7430c63a47f0664c0e4e2"
+checksum = "b08db04817a654a7e3339647d9cf8b497ed9ddcd4ec7cfda5a3a220c10a3bba3"
 dependencies = [
  "base64 0.22.1",
  "block2 0.6.1",
@@ -5749,6 +5869,7 @@ dependencies = [
  "ordered-stream",
  "serde",
  "serde_repr",
+ "tokio",
  "tracing",
  "uds_windows",
  "windows-sys 0.59.0",
@@ -5874,6 +5995,7 @@ dependencies = [
  "endi",
  "enumflags2",
  "serde",
+ "url",
  "winnow 0.7.11",
  "zvariant_derive",
  "zvariant_utils",

--- a/moodeSky/src/lib/components/BottomNavigation.svelte
+++ b/moodeSky/src/lib/components/BottomNavigation.svelte
@@ -33,11 +33,15 @@
   let activeAccount = $state<Account | null>(null);
   
   // アクティブアカウントを取得
-  $effect(async () => {
-    const result = await authService.getActiveAccount();
-    if (result.success && result.data) {
-      activeAccount = result.data;
-    }
+  $effect(() => {
+    const loadActiveAccount = async () => {
+      const result = await authService.getActiveAccount();
+      if (result.success && result.data) {
+        activeAccount = result.data;
+      }
+    };
+    
+    loadActiveAccount();
   });
   
   interface NavItem {

--- a/moodeSky/src/lib/components/BottomNavigation.svelte
+++ b/moodeSky/src/lib/components/BottomNavigation.svelte
@@ -11,21 +11,17 @@
   import AddDeckModal from '$lib/deck/components/AddDeckModal.svelte';
   import { ICONS } from '$lib/types/icon.js';
   import { useTranslation } from '$lib/utils/reactiveTranslation.svelte.js';
-  import { deckStore } from '$lib/deck/store.svelte.js';
   import { debugLog } from '$lib/utils/debugUtils.js';
   import { authService } from '$lib/services/authStore.js';
   import type { Account } from '$lib/types/auth.js';
   import type { Column } from '$lib/deck/types.js';
-  import * as m from '../../paraglide/messages.js';
   
   // リアクティブ翻訳システム
   const { t } = useTranslation();
   
   // $propsを使用してプロップを受け取る（Svelte 5 runes mode）
-  const { currentPath = '', accountId = '', onAddDeck } = $props<{ 
-    currentPath?: string; 
-    accountId?: string; 
-    onAddDeck?: () => void;
+  const { currentPath = '' } = $props<{ 
+    currentPath?: string;
   }>();
   
   // グローバルなデッキ追加モーダル状態管理

--- a/moodeSky/src/lib/components/Navigation.svelte
+++ b/moodeSky/src/lib/components/Navigation.svelte
@@ -52,7 +52,7 @@
 {#if isDesktop}
   <!-- デスクトップ・タブレット用サイドナビゲーション (768px以上) -->
   {console.log('🔍 [Navigation] Rendering desktop navigation (SideNavigation)')}
-  <SideNavigation {currentPath} {accountId} {onAddDeck} />
+  <SideNavigation {currentPath} />
 {:else}
   <!-- モバイル用ナビゲーション (768px未満) -->
   {console.log('🔍 [Navigation] Rendering mobile navigation')}
@@ -62,5 +62,5 @@
   {/if}
   
   <!-- モバイル用ボトムナビゲーション -->
-  <BottomNavigation {currentPath} {accountId} {onAddDeck} />
+  <BottomNavigation {currentPath} />
 {/if}

--- a/moodeSky/src/lib/components/SideNavigation.svelte
+++ b/moodeSky/src/lib/components/SideNavigation.svelte
@@ -38,11 +38,15 @@
   let activeAccount = $state<Account | null>(null);
   
   // アクティブアカウントを取得
-  $effect(async () => {
-    const result = await authService.getActiveAccount();
-    if (result.success && result.data) {
-      activeAccount = result.data;
-    }
+  $effect(() => {
+    const loadActiveAccount = async () => {
+      const result = await authService.getActiveAccount();
+      if (result.success && result.data) {
+        activeAccount = result.data;
+      }
+    };
+    
+    loadActiveAccount();
   });
   
   interface NavItem {

--- a/moodeSky/src/lib/components/SideNavigation.svelte
+++ b/moodeSky/src/lib/components/SideNavigation.svelte
@@ -39,6 +39,14 @@
       const result = await authService.getActiveAccount();
       if (result.success && result.data) {
         activeAccount = result.data;
+        debugLog('🔍 [SideNavigation] Active account loaded:', {
+          handle: activeAccount.profile.handle,
+          displayName: activeAccount.profile.displayName,
+          avatar: activeAccount.profile.avatar,
+          avatarAvailable: !!activeAccount.profile.avatar
+        });
+      } else {
+        debugLog('⚠️ [SideNavigation] Failed to load active account:', result);
       }
     };
     
@@ -123,6 +131,7 @@
   class="fixed left-0 top-0 bottom-0 z-40 w-64 bg-card border-r border-subtle shadow-lg flex flex-col"
   aria-label={t('navigation.home')}
 >
+
   <!-- 上部: 投稿ボタン -->
   <div class="flex-shrink-0 p-4">
     <button

--- a/moodeSky/src/lib/components/SideNavigation.svelte
+++ b/moodeSky/src/lib/components/SideNavigation.svelte
@@ -13,21 +13,17 @@
   import AddDeckModal from '$lib/deck/components/AddDeckModal.svelte';
   import { ICONS } from '$lib/types/icon.js';
   import { useTranslation } from '$lib/utils/reactiveTranslation.svelte.js';
-  import { deckStore } from '$lib/deck/store.svelte.js';
   import { debugLog } from '$lib/utils/debugUtils.js';
   import { authService } from '$lib/services/authStore.js';
   import type { Account } from '$lib/types/auth.js';
   import type { Column } from '$lib/deck/types.js';
-  import * as m from '../../paraglide/messages.js';
   
   // リアクティブ翻訳システム
   const { t } = useTranslation();
   
   // $propsを使用してプロップを受け取る（Svelte 5 runes mode）
-  const { currentPath = '', accountId = '', onAddDeck } = $props<{ 
-    currentPath?: string; 
-    accountId?: string; 
-    onAddDeck?: () => void;
+  const { currentPath = '' } = $props<{ 
+    currentPath?: string;
   }>();
   
   // デバッグログ追加

--- a/moodeSky/src/lib/components/ui/Button.svelte
+++ b/moodeSky/src/lib/components/ui/Button.svelte
@@ -5,6 +5,7 @@
   4バリアント × 3サイズ × 状態管理 + ハイコントラスト対応
 -->
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import Icon from '$lib/components/Icon.svelte';
   import { ICONS } from '$lib/types/icon.js';
   import type { ButtonProps } from './types.js';
@@ -23,8 +24,9 @@
     type = 'button',
     onclick,
     ariaLabel,
-    class: additionalClass = ''
-  }: ButtonProps = $props();
+    class: additionalClass = '',
+    children
+  }: ButtonProps & { children: Snippet } = $props();
 
   // ===================================================================
   // 動的スタイル生成（$derived）
@@ -224,7 +226,7 @@
   {/if}
 
   <!-- ボタンテキスト -->
-  <slot />
+  {@render children()}
 
   <!-- 右アイコン -->
   {#if rightIcon && !loading}

--- a/moodeSky/src/lib/components/ui/Button.test.ts
+++ b/moodeSky/src/lib/components/ui/Button.test.ts
@@ -8,6 +8,16 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import Button from './Button.svelte';
 import { ICONS } from '$lib/types/icon.js';
 
+// Snippet テスト用ヘルパー - Svelte 5互換
+const createTestSnippet = (content = 'Test Button') => {
+  const snippet = () => {
+    const result = document.createTextNode(content);
+    return result;
+  };
+  (snippet as any)['@@render'] = true;
+  return snippet as any;
+};
+
 describe('Button Component', () => {
   beforeEach(() => {
     // 各テスト前にモックをリセット
@@ -19,7 +29,7 @@ describe('Button Component', () => {
   // ===================================================================
 
   it('should render with default props', () => {
-    render(Button);
+    render(Button, { props: { children: createTestSnippet() } });
     
     const button = screen.getByRole('button');
     expect(button).toBeInTheDocument();
@@ -32,14 +42,14 @@ describe('Button Component', () => {
   // ===================================================================
 
   it('should apply primary variant classes by default', () => {
-    render(Button);
+    render(Button, { props: { children: createTestSnippet() } });
     
     const button = screen.getByRole('button');
     expect(button).toHaveClass('button-primary');
   });
 
   it('should apply secondary variant classes', () => {
-    render(Button, { props: { variant: 'secondary' } });
+    render(Button, { props: { variant: 'secondary', children: createTestSnippet() } });
     
     const button = screen.getByRole('button');
     expect(button.className).toContain('bg-muted/10');
@@ -48,7 +58,7 @@ describe('Button Component', () => {
   });
 
   it('should apply outline variant classes', () => {
-    render(Button, { props: { variant: 'outline' } });
+    render(Button, { props: { variant: 'outline', children: createTestSnippet() } });
     
     const button = screen.getByRole('button');
     expect(button.className).toContain('bg-transparent');
@@ -57,7 +67,7 @@ describe('Button Component', () => {
   });
 
   it('should apply ghost variant classes', () => {
-    render(Button, { props: { variant: 'ghost' } });
+    render(Button, { props: { variant: 'ghost', children: createTestSnippet() } });
     
     const button = screen.getByRole('button');
     expect(button.className).toContain('bg-transparent');
@@ -69,7 +79,7 @@ describe('Button Component', () => {
   // ===================================================================
 
   it('should apply medium size classes by default', () => {
-    render(Button);
+    render(Button, { props: { children: createTestSnippet() } });
     
     const button = screen.getByRole('button');
     expect(button.className).toContain('px-6');
@@ -77,7 +87,7 @@ describe('Button Component', () => {
   });
 
   it('should apply small size classes', () => {
-    render(Button, { props: { size: 'sm' } });
+    render(Button, { props: { size: 'sm', children: createTestSnippet() } });
     
     const button = screen.getByRole('button');
     expect(button.className).toContain('px-4');
@@ -86,7 +96,7 @@ describe('Button Component', () => {
   });
 
   it('should apply large size classes', () => {
-    render(Button, { props: { size: 'lg' } });
+    render(Button, { props: { size: 'lg', children: createTestSnippet() } });
     
     const button = screen.getByRole('button');
     expect(button.className).toContain('px-8');
@@ -99,7 +109,7 @@ describe('Button Component', () => {
   // ===================================================================
 
   it('should be disabled when disabled prop is true', () => {
-    render(Button, { props: { disabled: true } });
+    render(Button, { props: { disabled: true, children: createTestSnippet() } });
     
     const button = screen.getByRole('button');
     expect(button).toBeDisabled();
@@ -109,7 +119,7 @@ describe('Button Component', () => {
   });
 
   it('should show loading state', () => {
-    render(Button, { props: { loading: true } });
+    render(Button, { props: { loading: true, children: createTestSnippet() } });
     
     const button = screen.getByRole('button');
     expect(button).toBeDisabled();
@@ -123,14 +133,14 @@ describe('Button Component', () => {
   // ===================================================================
 
   it('should render left icon', () => {
-    render(Button, { props: { leftIcon: ICONS.ARROW_LEFT } });
+    render(Button, { props: { leftIcon: ICONS.ARROW_LEFT, children: createTestSnippet() } });
     
     const button = screen.getByRole('button');
     expect(button.className).toContain('gap-2');
   });
 
   it('should render right icon', () => {
-    render(Button, { props: { rightIcon: ICONS.ARROW_RIGHT } });
+    render(Button, { props: { rightIcon: ICONS.ARROW_RIGHT, children: createTestSnippet() } });
     
     const button = screen.getByRole('button');
     expect(button.className).toContain('gap-2');
@@ -142,7 +152,7 @@ describe('Button Component', () => {
 
   it('should call onclick when clicked', async () => {
     const handleClick = vi.fn();
-    render(Button, { props: { onclick: handleClick } });
+    render(Button, { props: { onclick: handleClick, children: createTestSnippet() } });
     
     const button = screen.getByRole('button');
     await fireEvent.click(button);
@@ -152,7 +162,7 @@ describe('Button Component', () => {
 
   it('should not call onclick when disabled', async () => {
     const handleClick = vi.fn();
-    render(Button, { props: { onclick: handleClick, disabled: true } });
+    render(Button, { props: { onclick: handleClick, disabled: true, children: createTestSnippet() } });
     
     const button = screen.getByRole('button');
     await fireEvent.click(button);
@@ -162,7 +172,7 @@ describe('Button Component', () => {
 
   it('should not call onclick when loading', async () => {
     const handleClick = vi.fn();
-    render(Button, { props: { onclick: handleClick, loading: true } });
+    render(Button, { props: { onclick: handleClick, loading: true, children: createTestSnippet() } });
     
     const button = screen.getByRole('button');
     await fireEvent.click(button);
@@ -176,7 +186,7 @@ describe('Button Component', () => {
       throw new Error('Test error');
     });
     
-    render(Button, { props: { onclick: errorHandler } });
+    render(Button, { props: { onclick: errorHandler, children: createTestSnippet() } });
     
     const button = screen.getByRole('button');
     await fireEvent.click(button);
@@ -194,7 +204,7 @@ describe('Button Component', () => {
 
   it('should handle Enter key press', async () => {
     const handleClick = vi.fn();
-    render(Button, { props: { onclick: handleClick } });
+    render(Button, { props: { onclick: handleClick, children: createTestSnippet() } });
     
     const button = screen.getByRole('button');
     button.focus();
@@ -205,7 +215,7 @@ describe('Button Component', () => {
 
   it('should handle Space key press', async () => {
     const handleClick = vi.fn();
-    render(Button, { props: { onclick: handleClick } });
+    render(Button, { props: { onclick: handleClick, children: createTestSnippet() } });
     
     const button = screen.getByRole('button');
     button.focus();
@@ -216,7 +226,7 @@ describe('Button Component', () => {
 
   it('should not handle keyboard when disabled', async () => {
     const handleClick = vi.fn();
-    render(Button, { props: { onclick: handleClick, disabled: true } });
+    render(Button, { props: { onclick: handleClick, disabled: true, children: createTestSnippet() } });
     
     const button = screen.getByRole('button');
     await fireEvent.keyDown(button, { key: 'Enter' });
@@ -230,7 +240,7 @@ describe('Button Component', () => {
   // ===================================================================
 
   it('should have proper aria attributes', () => {
-    render(Button, { props: { ariaLabel: 'Test Aria Label' } });
+    render(Button, { props: { ariaLabel: 'Test Aria Label', children: createTestSnippet() } });
     
     const button = screen.getByRole('button');
     expect(button).toHaveAttribute('aria-label', 'Test Aria Label');
@@ -239,7 +249,7 @@ describe('Button Component', () => {
   });
 
   it('should have proper aria attributes when disabled', () => {
-    render(Button, { props: { disabled: true } });
+    render(Button, { props: { disabled: true, children: createTestSnippet() } });
     
     const button = screen.getByRole('button');
     expect(button).toHaveAttribute('aria-disabled', 'true');
@@ -247,7 +257,7 @@ describe('Button Component', () => {
   });
 
   it('should have proper aria attributes when loading', () => {
-    render(Button, { props: { loading: true } });
+    render(Button, { props: { loading: true, children: createTestSnippet() } });
     
     const button = screen.getByRole('button');
     expect(button).toHaveAttribute('aria-busy', 'true');
@@ -260,7 +270,7 @@ describe('Button Component', () => {
   // ===================================================================
 
   it('should apply additional CSS classes', () => {
-    render(Button, { props: { class: 'custom-class another-class' } });
+    render(Button, { props: { class: 'custom-class another-class', children: createTestSnippet() } });
     
     const button = screen.getByRole('button');
     expect(button.className).toContain('custom-class');
@@ -268,7 +278,7 @@ describe('Button Component', () => {
   });
 
   it('should maintain base classes with additional classes', () => {
-    render(Button, { props: { class: 'custom-class' } });
+    render(Button, { props: { class: 'custom-class', children: createTestSnippet() } });
     
     const button = screen.getByRole('button');
     expect(button.className).toContain('custom-class');
@@ -282,7 +292,7 @@ describe('Button Component', () => {
   // ===================================================================
 
   it('should be focusable by default', () => {
-    render(Button);
+    render(Button, { props: { children: createTestSnippet() } });
     
     const button = screen.getByRole('button');
     button.focus();
@@ -290,7 +300,7 @@ describe('Button Component', () => {
   });
 
   it('should not be focusable when disabled', () => {
-    render(Button, { props: { disabled: true } });
+    render(Button, { props: { disabled: true, children: createTestSnippet() } });
     
     const button = screen.getByRole('button');
     expect(button).toHaveAttribute('tabindex', '-1');
@@ -301,14 +311,14 @@ describe('Button Component', () => {
   // ===================================================================
 
   it('should support submit type', () => {
-    render(Button, { props: { type: 'submit' } });
+    render(Button, { props: { type: 'submit', children: createTestSnippet() } });
     
     const button = screen.getByRole('button');
     expect(button).toHaveAttribute('type', 'submit');
   });
 
   it('should support reset type', () => {
-    render(Button, { props: { type: 'reset' } });
+    render(Button, { props: { type: 'reset', children: createTestSnippet() } });
     
     const button = screen.getByRole('button');
     expect(button).toHaveAttribute('type', 'reset');

--- a/moodeSky/src/lib/components/ui/Card.svelte
+++ b/moodeSky/src/lib/components/ui/Card.svelte
@@ -6,6 +6,7 @@
   4バリアント × 4状態 × レスポンシブ対応
 -->
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import type { CardProps } from './types.js';
 
   // ===================================================================
@@ -19,8 +20,9 @@
     clickable = false,
     onclick,
     ariaLabel,
-    class: additionalClass = ''
-  }: CardProps = $props();
+    class: additionalClass = '',
+    children
+  }: CardProps & { children: Snippet } = $props();
 
   // ===================================================================
   // 内部状態管理
@@ -226,12 +228,12 @@
     onblur={handleBlur}
     {...accessibilityAttributes()}
   >
-    <slot />
+    {@render children()}
   </div>
 {:else}
   <!-- 静的カード -->
   <div class={finalClasses()}>
-    <slot />
+    {@render children()}
   </div>
 {/if}
 

--- a/moodeSky/src/lib/components/ui/ConfirmationModal.svelte
+++ b/moodeSky/src/lib/components/ui/ConfirmationModal.svelte
@@ -158,6 +158,7 @@
   onClose={handleCancel}
   onEscapeKey={handleEscapeKey}
   {zIndex}
+  footer={footerSnippet}
 >
   <!-- メインコンテンツ -->
   <div class="text-center space-y-6 py-4">
@@ -187,31 +188,31 @@
     </div>
   </div>
 
-  <!-- フッター（ボタンエリア） -->
-  <svelte:fragment slot="footer">
-    <div class="flex flex-col-reverse sm:flex-row gap-3 justify-center sm:justify-end">
-      <!-- キャンセルボタン -->
-      <Button
-        variant="secondary"
-        size="lg"
-        onclick={handleCancel}
-        class="flex-1 sm:flex-initial sm:min-w-24"
-      >
-        {displayTexts().cancelText}
-      </Button>
-
-      <!-- 確認ボタン -->
-      <Button
-        variant={variantConfig().confirmButtonVariant}
-        size="lg"
-        onclick={handleConfirm}
-        class="flex-1 sm:flex-initial sm:min-w-24 {variantConfig().confirmButtonClass}"
-      >
-        {displayTexts().confirmText}
-      </Button>
-    </div>
-  </svelte:fragment>
 </Modal>
+
+{#snippet footerSnippet()}
+  <div class="flex flex-col-reverse sm:flex-row gap-3 justify-center sm:justify-end">
+    <!-- キャンセルボタン -->
+    <Button
+      variant="secondary"
+      size="lg"
+      onclick={handleCancel}
+      class="flex-1 sm:flex-initial sm:min-w-24"
+    >
+      {displayTexts().cancelText}
+    </Button>
+
+    <!-- 確認ボタン -->
+    <Button
+      variant={variantConfig().confirmButtonVariant}
+      size="lg"
+      onclick={handleConfirm}
+      class="flex-1 sm:flex-initial sm:min-w-24 {variantConfig().confirmButtonClass}"
+    >
+      {displayTexts().confirmText}
+    </Button>
+  </div>
+{/snippet}
 
 <!--
   使用例:

--- a/moodeSky/src/lib/components/ui/Modal.svelte
+++ b/moodeSky/src/lib/components/ui/Modal.svelte
@@ -41,22 +41,22 @@
   // ===================================================================
 
   /**
-   * サイズ別クラス
+   * サイズ別クラス（モバイルレスポンシブ対応）
    */
   const sizeClasses = $derived(() => {
     switch (size) {
       case 'sm':
-        return 'max-w-md';
+        return 'max-w-[calc(100vw-1rem)] sm:max-w-md';
       case 'md':
-        return 'max-w-2xl';
+        return 'max-w-[calc(100vw-1rem)] sm:max-w-2xl';
       case 'lg':
-        return 'max-w-4xl';
+        return 'max-w-[calc(100vw-1rem)] sm:max-w-4xl';
       case 'xl':
-        return 'max-w-6xl';
+        return 'max-w-[calc(100vw-1rem)] sm:max-w-6xl';
       case 'full':
         return 'max-w-none mx-4';
       default:
-        return 'max-w-4xl';
+        return 'max-w-[calc(100vw-1rem)] sm:max-w-4xl';
     }
   });
 
@@ -72,10 +72,10 @@
   });
 
   /**
-   * オーバーレイクラス（tokimekibluesky参考の配置戦略）
+   * オーバーレイクラス（モバイル最適化パディング）
    */
   const overlayClasses = $derived(() => 
-    `fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center ${zIndexStyle()} p-4 transition-all duration-300`
+    `fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center ${zIndexStyle()} p-2 sm:p-4 transition-all duration-300`
   );
 
   /**

--- a/moodeSky/src/lib/components/ui/Modal.svelte
+++ b/moodeSky/src/lib/components/ui/Modal.svelte
@@ -5,6 +5,7 @@
   既存モーダル構造の統一 + slot-based設計 + 完全アクセシビリティ対応
 -->
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import { onMount } from 'svelte';
   import Icon from '$lib/components/Icon.svelte';
   import { ICONS } from '$lib/types/icon.js';
@@ -24,8 +25,11 @@
     showCloseButton = true,
     onClose,
     onEscapeKey,
-    zIndex = 50
-  }: ModalProps = $props();
+    zIndex = 50,
+    children,
+    header,
+    footer
+  }: ModalProps & { children: Snippet; header?: Snippet; footer?: Snippet } = $props();
 
   // ===================================================================
   // 内部状態管理
@@ -288,7 +292,9 @@
               {/if}
               
               <!-- ヘッダースロット -->
-              <slot name="header" />
+              {#if header}
+                {@render header()}
+              {/if}
             </div>
 
             <!-- 閉じるボタン -->
@@ -309,13 +315,15 @@
 
       <!-- コンテンツエリア -->
       <div class="p-8 overflow-y-auto flex-1 custom-scrollbar">
-        <slot />
+        {@render children()}
       </div>
 
       <!-- フッター -->
       {#if showFooter}
         <div class="bg-gradient-to-r from-muted/5 to-muted/10 px-8 py-6">
-          <slot name="footer" />
+          {#if footer}
+            {@render footer()}
+          {/if}
         </div>
       {/if}
     </div>

--- a/moodeSky/src/lib/components/ui/Modal.test.ts
+++ b/moodeSky/src/lib/components/ui/Modal.test.ts
@@ -7,6 +7,16 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import Modal from './Modal.svelte';
 
+// Snippet テスト用ヘルパー - Svelte 5互換
+const createTestSnippet = (content = 'Test Modal Content') => {
+  const snippet = () => {
+    const result = document.createTextNode(content);
+    return result;
+  };
+  (snippet as any)['@@render'] = true;
+  return snippet as any;
+};
+
 describe('Modal Component', () => {
   let originalOverflow: string;
 
@@ -38,19 +48,19 @@ describe('Modal Component', () => {
   // ===================================================================
 
   it('should not render when isOpen is false', () => {
-    render(Modal, { props: { isOpen: false, onClose: vi.fn() } });
+    render(Modal, { props: { isOpen: false, onClose: vi.fn(), children: createTestSnippet() } });
     
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 
   it('should render when isOpen is true', () => {
-    render(Modal, { props: { isOpen: true, onClose: vi.fn() } });
+    render(Modal, { props: { isOpen: true, onClose: vi.fn(), children: createTestSnippet() } });
     
     expect(screen.getByRole('dialog')).toBeInTheDocument();
   });
 
   it('should render with title', () => {
-    render(Modal, { props: { isOpen: true, title: 'Test Modal Title', onClose: vi.fn() } });
+    render(Modal, { props: { isOpen: true, title: 'Test Modal Title', onClose: vi.fn(), children: createTestSnippet() } });
     
     expect(screen.getByText('Test Modal Title')).toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Test Modal Title');
@@ -61,35 +71,35 @@ describe('Modal Component', () => {
   // ===================================================================
 
   it('should apply default large size classes', () => {
-    render(Modal, { props: { isOpen: true, onClose: vi.fn() } });
+    render(Modal, { props: { isOpen: true, onClose: vi.fn(), children: createTestSnippet() } });
     
     const modalContainer = screen.getByRole('document');
     expect(modalContainer.className).toContain('max-w-4xl');
   });
 
   it('should apply small size classes', () => {
-    render(Modal, { props: { isOpen: true, size: 'sm', onClose: vi.fn() } });
+    render(Modal, { props: { isOpen: true, size: 'sm', onClose: vi.fn(), children: createTestSnippet() } });
     
     const modalContainer = screen.getByRole('document');
     expect(modalContainer.className).toContain('max-w-md');
   });
 
   it('should apply medium size classes', () => {
-    render(Modal, { props: { isOpen: true, size: 'md', onClose: vi.fn() } });
+    render(Modal, { props: { isOpen: true, size: 'md', onClose: vi.fn(), children: createTestSnippet() } });
     
     const modalContainer = screen.getByRole('document');
     expect(modalContainer.className).toContain('max-w-2xl');
   });
 
   it('should apply extra large size classes', () => {
-    render(Modal, { props: { isOpen: true, size: 'xl', onClose: vi.fn() } });
+    render(Modal, { props: { isOpen: true, size: 'xl', onClose: vi.fn(), children: createTestSnippet() } });
     
     const modalContainer = screen.getByRole('document');
     expect(modalContainer.className).toContain('max-w-6xl');
   });
 
   it('should apply full size classes', () => {
-    render(Modal, { props: { isOpen: true, size: 'full', onClose: vi.fn() } });
+    render(Modal, { props: { isOpen: true, size: 'full', onClose: vi.fn(), children: createTestSnippet() } });
     
     const modalContainer = screen.getByRole('document');
     expect(modalContainer.className).toContain('max-w-none');
@@ -101,19 +111,19 @@ describe('Modal Component', () => {
   // ===================================================================
 
   it('should show header by default', () => {
-    render(Modal, { props: { isOpen: true, title: 'Test Title', onClose: vi.fn() } });
+    render(Modal, { props: { isOpen: true, title: 'Test Title', onClose: vi.fn(), children: createTestSnippet() } });
     
     expect(screen.getByText('Test Title')).toBeInTheDocument();
   });
 
   it('should hide header when showHeader is false', () => {
-    render(Modal, { props: { isOpen: true, title: 'Test Title', showHeader: false, onClose: vi.fn() } });
+    render(Modal, { props: { isOpen: true, title: 'Test Title', showHeader: false, onClose: vi.fn(), children: createTestSnippet() } });
     
     expect(screen.queryByText('Test Title')).not.toBeInTheDocument();
   });
 
   it('should show close button by default', () => {
-    render(Modal, { props: { isOpen: true, title: 'Test Title', onClose: vi.fn() } });
+    render(Modal, { props: { isOpen: true, title: 'Test Title', onClose: vi.fn(), children: createTestSnippet() } });
     
     const closeButton = screen.getByLabelText('モーダルを閉じる');
     expect(closeButton).toBeInTheDocument();
@@ -125,7 +135,8 @@ describe('Modal Component', () => {
         isOpen: true, 
         title: 'Test Title', 
         showCloseButton: false, 
-        onClose: vi.fn() 
+        onClose: vi.fn(),
+        children: createTestSnippet()
       }
     });
     
@@ -133,7 +144,7 @@ describe('Modal Component', () => {
   });
 
   it('should not show footer by default', () => {
-    const { container } = render(Modal, { props: { isOpen: true, onClose: vi.fn() } });
+    const { container } = render(Modal, { props: { isOpen: true, onClose: vi.fn(), children: createTestSnippet() } });
     
     // フッターのDOMが存在しないことを確認
     const footerElement = container.querySelector('.bg-gradient-to-r.from-muted\\/5');
@@ -146,7 +157,7 @@ describe('Modal Component', () => {
 
   it('should call onClose when close button is clicked', async () => {
     const onClose = vi.fn();
-    render(Modal, { props: { isOpen: true, title: 'Test Title', onClose } });
+    render(Modal, { props: { isOpen: true, title: 'Test Title', onClose, children: createTestSnippet() } });
     
     const closeButton = screen.getByLabelText('モーダルを閉じる');
     await fireEvent.click(closeButton);
@@ -156,7 +167,7 @@ describe('Modal Component', () => {
 
   it('should call onClose when overlay is clicked', async () => {
     const onClose = vi.fn();
-    render(Modal, { props: { isOpen: true, onClose } });
+    render(Modal, { props: { isOpen: true, onClose, children: createTestSnippet() } });
     
     const overlay = screen.getByRole('dialog');
     await fireEvent.click(overlay);
@@ -170,7 +181,7 @@ describe('Modal Component', () => {
 
   it('should call onClose when Escape key is pressed', async () => {
     const onClose = vi.fn();
-    render(Modal, { props: { isOpen: true, onClose } });
+    render(Modal, { props: { isOpen: true, onClose, children: createTestSnippet() } });
     
     await fireEvent.keyDown(document, { key: 'Escape' });
     
@@ -180,7 +191,7 @@ describe('Modal Component', () => {
   it('should call custom onEscapeKey when provided', async () => {
     const onClose = vi.fn();
     const onEscapeKey = vi.fn();
-    render(Modal, { props: { isOpen: true, onClose, onEscapeKey } });
+    render(Modal, { props: { isOpen: true, onClose, onEscapeKey, children: createTestSnippet() } });
     
     await fireEvent.keyDown(document, { key: 'Escape' });
     
@@ -193,7 +204,7 @@ describe('Modal Component', () => {
   // ===================================================================
 
   it('should have proper ARIA attributes', () => {
-    render(Modal, { props: { isOpen: true, title: 'Test Title', onClose: vi.fn() } });
+    render(Modal, { props: { isOpen: true, title: 'Test Title', onClose: vi.fn(), children: createTestSnippet() } });
     
     const dialog = screen.getByRole('dialog');
     expect(dialog).toHaveAttribute('aria-modal', 'true');
@@ -205,7 +216,7 @@ describe('Modal Component', () => {
   });
 
   it('should have proper ARIA attributes without title', () => {
-    render(Modal, { props: { isOpen: true, onClose: vi.fn() } });
+    render(Modal, { props: { isOpen: true, onClose: vi.fn(), children: createTestSnippet() } });
     
     const dialog = screen.getByRole('dialog');
     expect(dialog).toHaveAttribute('aria-modal', 'true');
@@ -217,7 +228,7 @@ describe('Modal Component', () => {
   // ===================================================================
 
   it('should disable body scroll when open', async () => {
-    render(Modal, { props: { isOpen: true, onClose: vi.fn() } });
+    render(Modal, { props: { isOpen: true, onClose: vi.fn(), children: createTestSnippet() } });
     
     // 非同期でDOM更新を待つ
     await waitFor(() => {
@@ -226,7 +237,7 @@ describe('Modal Component', () => {
   });
 
   it('should restore body scroll when closed', async () => {
-    const { rerender } = render(Modal, { props: { isOpen: true, onClose: vi.fn() } });
+    const { rerender } = render(Modal, { props: { isOpen: true, onClose: vi.fn(), children: createTestSnippet() } });
     
     // モーダルが開いている状態でbodyスクロールが無効化されることを確認
     await waitFor(() => {
@@ -234,7 +245,7 @@ describe('Modal Component', () => {
     });
     
     // モーダルを閉じる
-    await rerender({ isOpen: false, onClose: vi.fn() });
+    await rerender({ isOpen: false, onClose: vi.fn(), children: createTestSnippet() });
     
     // bodyスクロールが復元されることを確認
     await waitFor(() => {
@@ -247,14 +258,14 @@ describe('Modal Component', () => {
   // ===================================================================
 
   it('should apply default z-index', () => {
-    render(Modal, { props: { isOpen: true, onClose: vi.fn() } });
+    render(Modal, { props: { isOpen: true, onClose: vi.fn(), children: createTestSnippet() } });
     
     const overlay = screen.getByRole('dialog');
     expect(overlay.className).toContain('z-50');
   });
 
   it('should apply custom z-index', () => {
-    render(Modal, { props: { isOpen: true, zIndex: 999, onClose: vi.fn() } });
+    render(Modal, { props: { isOpen: true, zIndex: 999, onClose: vi.fn(), children: createTestSnippet() } });
     
     const overlay = screen.getByRole('dialog');
     expect(overlay.className).toContain('z-999');
@@ -280,7 +291,7 @@ describe('Modal Component', () => {
     });
     
     const onClose = vi.fn();
-    render(Modal, { props: { isOpen: true, onClose } });
+    render(Modal, { props: { isOpen: true, onClose, children: createTestSnippet() } });
     
     // モーダルを閉じる
     const closeButton = screen.getByLabelText('モーダルを閉じる');
@@ -300,7 +311,7 @@ describe('Modal Component', () => {
   // ===================================================================
 
   it('should apply responsive classes', () => {
-    render(Modal, { props: { isOpen: true, onClose: vi.fn() } });
+    render(Modal, { props: { isOpen: true, onClose: vi.fn(), children: createTestSnippet() } });
     
     const overlay = screen.getByRole('dialog');
     expect(overlay.className).toContain('p-4');
@@ -318,7 +329,7 @@ describe('Modal Component', () => {
   // ===================================================================
 
   it('should apply theme-based styling', () => {
-    render(Modal, { props: { isOpen: true, title: 'Styled Modal', onClose: vi.fn() } });
+    render(Modal, { props: { isOpen: true, title: 'Styled Modal', onClose: vi.fn(), children: createTestSnippet() } });
     
     const container = screen.getByRole('document');
     expect(container.className).toContain('bg-card');

--- a/moodeSky/src/lib/deck/components/AddDeckModal.svelte
+++ b/moodeSky/src/lib/deck/components/AddDeckModal.svelte
@@ -47,27 +47,29 @@
   onClose={handleClose}
   showFooter={true}
   size="lg"
+  header={headerSnippet}
+  footer={footerSnippet}
 >
-  <!-- ヘッダーサブタイトル -->
-  <svelte:fragment slot="header">
-    <p class="text-secondary text-lg leading-relaxed">
-      {m['deck.addDeck.subtitle']()}
-    </p>
-  </svelte:fragment>
 
   <!-- メインコンテンツ -->
   <SimpleFeedAdder onSuccess={handleSuccess} />
 
-  <!-- フッターボタン -->
-  <svelte:fragment slot="footer">
-    <div class="flex justify-end">
-      <Button 
-        variant="secondary" 
-        onclick={handleClose}
-        size="md"
-      >
-        {m['deck.addDeck.buttons.cancel']()}
-      </Button>
-    </div>
-  </svelte:fragment>
 </Modal>
+
+{#snippet headerSnippet()}
+  <p class="text-secondary text-lg leading-relaxed">
+    {m['deck.addDeck.subtitle']()}
+  </p>
+{/snippet}
+
+{#snippet footerSnippet()}
+  <div class="flex justify-end">
+    <Button 
+      variant="secondary" 
+      onclick={handleClose}
+      size="md"
+    >
+      {m['deck.addDeck.buttons.cancel']()}
+    </Button>
+  </div>
+{/snippet}

--- a/moodeSky/src/lib/deck/components/DeckContainer.svelte
+++ b/moodeSky/src/lib/deck/components/DeckContainer.svelte
@@ -28,12 +28,13 @@
 
   interface Props {
     accountId: string;
+    activeAccount?: import('$lib/types/auth.js').Account;
     className?: string;
     showAddDeckModal?: boolean;
     onCloseAddDeckModal?: () => void;
   }
 
-  const { accountId, className = '', showAddDeckModal: externalShowAddDeckModal = false, onCloseAddDeckModal }: Props = $props();
+  const { accountId, activeAccount, className = '', showAddDeckModal: externalShowAddDeckModal = false, onCloseAddDeckModal }: Props = $props();
 
   // ===================================================================
   // 状態管理
@@ -1045,6 +1046,7 @@
                 {column}
                 {index}
                 {accountId}
+                {activeAccount}
                 onOpenDeckSettings={() => handleOpenSettings(column)}
               />
             </div>
@@ -1065,6 +1067,7 @@
               {column}
               {index}
               {accountId}
+              {activeAccount}
               onOpenDeckSettings={() => handleOpenSettings(column)}
             />
           </div>

--- a/moodeSky/src/lib/deck/components/FeedConfigModal.svelte
+++ b/moodeSky/src/lib/deck/components/FeedConfigModal.svelte
@@ -215,7 +215,7 @@
 <!-- 統一UIコンポーネントシステム -->
 <Modal 
   isOpen={isOpen && !!feedType}
-  title={m['deck.addDeck.feedConfig.title']({ feedType: feedType?.name || '' })}
+  title={m['deck.addDeck.feedConfig.title']({ feedType: feedType?.name ?? 'Unknown' })}
   onClose={handleClose}
   showFooter={true}
   size="lg"

--- a/moodeSky/src/lib/deck/components/FeedConfigModal.svelte
+++ b/moodeSky/src/lib/deck/components/FeedConfigModal.svelte
@@ -282,21 +282,28 @@
 
   <!-- フッターボタン -->
   <svelte:fragment slot="footer">
-    <div class="flex justify-between">
-      <Button 
-        variant="secondary" 
-        onclick={handleBack}
-        leftIcon={ICONS.ARROW_BACK}
-        size="md"
-      >
-        {m['deck.addDeck.buttons.previous']()}
-      </Button>
+    <!-- モバイル: 縦並び、デスクトップ: 横並び -->
+    <div class="flex flex-col sm:flex-row sm:justify-between gap-3">
+      <!-- 戻るボタン -->
+      <div class="flex justify-center sm:justify-start">
+        <Button 
+          variant="secondary" 
+          onclick={handleBack}
+          leftIcon={ICONS.ARROW_BACK}
+          size="md"
+          class="w-full sm:w-auto"
+        >
+          {m['deck.addDeck.buttons.previous']()}
+        </Button>
+      </div>
       
-      <div class="flex gap-3">
+      <!-- キャンセル・作成ボタン -->
+      <div class="flex flex-col sm:flex-row gap-3">
         <Button 
           variant="secondary" 
           onclick={handleClose}
           size="md"
+          class="w-full sm:w-auto"
         >
           {m['deck.addDeck.buttons.cancel']()}
         </Button>
@@ -307,6 +314,7 @@
           loading={isLoading}
           leftIcon={isLoading ? undefined : ICONS.ADD}
           size="md"
+          class="w-full sm:w-auto"
         >
           {m['deck.addDeck.buttons.create']()}
         </Button>

--- a/moodeSky/src/lib/deck/components/FeedConfigModal.svelte
+++ b/moodeSky/src/lib/deck/components/FeedConfigModal.svelte
@@ -218,7 +218,7 @@
   title={feedType ? `${feedType.name}の設定` : ''}
   onClose={handleClose}
   showFooter={true}
-  size="xl"
+  size="lg"
 >
   <!-- ヘッダーサブタイトル -->
   <svelte:fragment slot="header">

--- a/moodeSky/src/lib/deck/components/FeedConfigModal.svelte
+++ b/moodeSky/src/lib/deck/components/FeedConfigModal.svelte
@@ -215,7 +215,7 @@
 <!-- 統一UIコンポーネントシステム -->
 <Modal 
   isOpen={isOpen && !!feedType}
-  title={feedType ? `${feedType.name}の設定` : ''}
+  title={m['deck.addDeck.feedConfig.title']({ feedType: feedType?.name || '' })}
   onClose={handleClose}
   showFooter={true}
   size="lg"
@@ -282,28 +282,28 @@
 
   <!-- フッターボタン -->
   <svelte:fragment slot="footer">
-    <!-- モバイル: 縦並び、デスクトップ: 横並び -->
-    <div class="flex flex-col sm:flex-row sm:justify-between gap-3">
+    <!-- モバイル: 縦並び、タブレット以上: 横並び -->
+    <div class="flex flex-col md:flex-row md:justify-between gap-3 flex-wrap">
       <!-- 戻るボタン -->
-      <div class="flex justify-center sm:justify-start">
+      <div class="flex justify-center md:justify-start">
         <Button 
           variant="secondary" 
           onclick={handleBack}
           leftIcon={ICONS.ARROW_BACK}
           size="md"
-          class="w-full sm:w-auto"
+          class="w-full md:w-auto md:min-w-[120px]"
         >
           {m['deck.addDeck.buttons.previous']()}
         </Button>
       </div>
       
       <!-- キャンセル・作成ボタン -->
-      <div class="flex flex-col sm:flex-row gap-3">
+      <div class="flex flex-col md:flex-row gap-3">
         <Button 
           variant="secondary" 
           onclick={handleClose}
           size="md"
-          class="w-full sm:w-auto"
+          class="w-full md:w-auto md:min-w-[120px]"
         >
           {m['deck.addDeck.buttons.cancel']()}
         </Button>
@@ -314,7 +314,7 @@
           loading={isLoading}
           leftIcon={isLoading ? undefined : ICONS.ADD}
           size="md"
-          class="w-full sm:w-auto"
+          class="w-full md:w-auto md:min-w-[120px]"
         >
           {m['deck.addDeck.buttons.create']()}
         </Button>

--- a/moodeSky/src/lib/deck/components/FeedConfigModal.svelte
+++ b/moodeSky/src/lib/deck/components/FeedConfigModal.svelte
@@ -13,11 +13,9 @@
   import FeedSettings from './FeedSettings.svelte';
   import type { 
     FeedTypeConfig, 
-    Column,
-    ColumnAlgorithm 
+    Column
   } from '../types.js';
   import {
-    getFeedTypeConfig,
     getDefaultDeckName,
     getFeedTypeIcon
   } from '../types.js';

--- a/moodeSky/src/lib/deck/components/FeedConfigModal.svelte
+++ b/moodeSky/src/lib/deck/components/FeedConfigModal.svelte
@@ -217,15 +217,9 @@
   onClose={handleClose}
   showFooter={true}
   size="lg"
+  header={headerSnippet}
+  footer={footerSnippet}
 >
-  <!-- ヘッダーサブタイトル -->
-  <svelte:fragment slot="header">
-    {#if feedType}
-      <p class="text-secondary text-lg leading-relaxed">
-        {feedType.description}
-      </p>
-    {/if}
-  </svelte:fragment>
 
   <!-- エラーメッセージ -->
   {#if errorMessage}
@@ -278,45 +272,53 @@
     />
   </div>
 
-  <!-- フッターボタン -->
-  <svelte:fragment slot="footer">
-    <!-- モバイル: 縦並び、タブレット以上: 横並び -->
-    <div class="flex flex-col md:flex-row md:justify-between gap-3 flex-wrap">
-      <!-- 戻るボタン -->
-      <div class="flex justify-center md:justify-start">
-        <Button 
-          variant="secondary" 
-          onclick={handleBack}
-          leftIcon={ICONS.ARROW_BACK}
-          size="md"
-          class="w-full md:w-auto md:min-w-[120px]"
-        >
-          {m['deck.addDeck.buttons.previous']()}
-        </Button>
-      </div>
-      
-      <!-- キャンセル・作成ボタン -->
-      <div class="flex flex-col md:flex-row gap-3">
-        <Button 
-          variant="secondary" 
-          onclick={handleClose}
-          size="md"
-          class="w-full md:w-auto md:min-w-[120px]"
-        >
-          {m['deck.addDeck.buttons.cancel']()}
-        </Button>
-        <Button 
-          variant="primary" 
-          onclick={handleCreate}
-          disabled={isLoading || !selectedAccountId}
-          loading={isLoading}
-          leftIcon={isLoading ? undefined : ICONS.ADD}
-          size="md"
-          class="w-full md:w-auto md:min-w-[120px]"
-        >
-          {m['deck.addDeck.buttons.create']()}
-        </Button>
-      </div>
-    </div>
-  </svelte:fragment>
 </Modal>
+
+{#snippet headerSnippet()}
+  {#if feedType}
+    <p class="text-secondary text-lg leading-relaxed">
+      {feedType.description}
+    </p>
+  {/if}
+{/snippet}
+
+{#snippet footerSnippet()}
+  <!-- モバイル: 縦並び、タブレット以上: 横並び -->
+  <div class="flex flex-col md:flex-row md:justify-between gap-3 flex-wrap">
+    <!-- 戻るボタン -->
+    <div class="flex justify-center md:justify-start">
+      <Button 
+        variant="secondary" 
+        onclick={handleBack}
+        leftIcon={ICONS.ARROW_BACK}
+        size="md"
+        class="w-full md:w-auto md:min-w-[120px]"
+      >
+        {m['deck.addDeck.buttons.previous']()}
+      </Button>
+    </div>
+    
+    <!-- キャンセル・作成ボタン -->
+    <div class="flex flex-col md:flex-row gap-3">
+      <Button 
+        variant="secondary" 
+        onclick={handleClose}
+        size="md"
+        class="w-full md:w-auto md:min-w-[120px]"
+      >
+        {m['deck.addDeck.buttons.cancel']()}
+      </Button>
+      <Button 
+        variant="primary" 
+        onclick={handleCreate}
+        disabled={isLoading || !selectedAccountId}
+        loading={isLoading}
+        leftIcon={isLoading ? undefined : ICONS.ADD}
+        size="md"
+        class="w-full md:w-auto md:min-w-[120px]"
+      >
+        {m['deck.addDeck.buttons.create']()}
+      </Button>
+    </div>
+  </div>
+{/snippet}

--- a/moodeSky/src/lib/i18n/locales/en.json
+++ b/moodeSky/src/lib/i18n/locales/en.json
@@ -561,6 +561,24 @@
       "title": "Notification Settings",
       "description": "Notification settings feature is coming soon"
     },
+    "deckManagement": {
+      "title": "Deck Management",
+      "description": "Manage deck columns and their settings.",
+      "loading": "Loading decks...",
+      "addDeck": "Add Deck",
+      "existingDecks": "Existing Decks",
+      "algorithm": "Algorithm",
+      "createdAt": "Created At",
+      "settings": "Settings",
+      "delete": "Delete",
+      "noDecks": "No Decks Found",
+      "noDecksDescription": "You haven't created any decks yet. Add one to get started!",
+      "addFirstDeck": "Add Your First Deck",
+      "addSuccess": "Successfully added deck '{name}'.",
+      "deleteConfirmation": "Are you sure you want to delete the deck '{name}'?",
+      "deleteSuccess": "Successfully deleted deck '{name}'.",
+      "deleteError": "Failed to delete deck."
+    },
     "authRequired": "Authentication required",
     "closeMessage": "Close message"
   }

--- a/moodeSky/src/lib/i18n/locales/ja.json
+++ b/moodeSky/src/lib/i18n/locales/ja.json
@@ -562,6 +562,24 @@
       "title": "通知設定", 
       "description": "通知設定機能は準備中です"
     },
+    "deckManagement": {
+      "title": "デッキ管理",
+      "description": "デッキカラムとその設定を管理します。",
+      "loading": "デッキを読み込み中...",
+      "addDeck": "デッキを追加",
+      "existingDecks": "既存のデッキ",
+      "algorithm": "アルゴリズム",
+      "createdAt": "作成日",
+      "settings": "設定",
+      "delete": "削除",
+      "noDecks": "デッキが見つかりません",
+      "noDecksDescription": "まだデッキを作成していません。追加して始めましょう！",
+      "addFirstDeck": "最初のデッキを追加",
+      "addSuccess": "デッキ「{name}」を追加しました。",
+      "deleteConfirmation": "デッキ「{name}」を本当に削除しますか？",
+      "deleteSuccess": "デッキ「{name}」を削除しました。",
+      "deleteError": "デッキの削除に失敗しました。"
+    },
     "authRequired": "認証が必要です",
     "closeMessage": "メッセージを閉じる"
   },

--- a/moodeSky/src/lib/services/profileService.ts
+++ b/moodeSky/src/lib/services/profileService.ts
@@ -7,6 +7,7 @@
  */
 
 import { BskyAgent } from '@atproto/api';
+import { authService } from './authStore.js';
 
 /**
  * プロフィール統計情報
@@ -23,10 +24,36 @@ export interface ProfileStats {
 }
 
 /**
- * キャッシュエントリ
+ * 基本プロフィール情報（アバターキャッシュ用）
  */
-interface CacheEntry {
+export interface ProfileInfo {
+  /** アカウントDID */
+  did: string;
+  /** ハンドル名 */
+  handle: string;
+  /** 表示名 */
+  displayName?: string;
+  /** アバター画像URL */
+  avatar?: string;
+  /** プロフィール説明 */
+  description?: string;
+  /** 最終更新日時 */
+  lastUpdated: Date;
+}
+
+/**
+ * キャッシュエントリ（統計情報用）
+ */
+interface StatsCacheEntry {
   stats: ProfileStats;
+  expiredAt: number;
+}
+
+/**
+ * キャッシュエントリ（プロフィール情報用）
+ */
+interface ProfileCacheEntry {
+  profile: ProfileInfo;
   expiredAt: number;
 }
 
@@ -57,7 +84,8 @@ export interface ProfileServiceResult<T = ProfileStats> {
  * AT Protocol プロフィール統計サービス
  */
 export class ProfileService {
-  private cache = new Map<string, CacheEntry>();
+  private statsCache = new Map<string, StatsCacheEntry>();
+  private profileCache = new Map<string, ProfileCacheEntry>();
   private cacheExpiry = 5 * 60 * 1000; // 5分間キャッシュ
   
   /**
@@ -186,12 +214,12 @@ export class ProfileService {
    * キャッシュから統計情報を取得
    */
   private getCachedStats(did: string): ProfileStats | null {
-    const entry = this.cache.get(did);
+    const entry = this.statsCache.get(did);
     if (!entry) return null;
 
     // 期限切れチェック
     if (Date.now() > entry.expiredAt) {
-      this.cache.delete(did);
+      this.statsCache.delete(did);
       return null;
     }
 
@@ -202,11 +230,295 @@ export class ProfileService {
    * 統計情報をキャッシュに保存
    */
   private setCachedStats(did: string, stats: ProfileStats): void {
-    const entry: CacheEntry = {
+    const entry: StatsCacheEntry = {
       stats,
       expiredAt: Date.now() + this.cacheExpiry
     };
-    this.cache.set(did, entry);
+    this.statsCache.set(did, entry);
+  }
+
+  /**
+   * キャッシュからプロフィール情報を取得
+   */
+  private getCachedProfile(did: string): ProfileInfo | null {
+    const entry = this.profileCache.get(did);
+    if (!entry) return null;
+
+    // 期限切れチェック
+    if (Date.now() > entry.expiredAt) {
+      this.profileCache.delete(did);
+      return null;
+    }
+
+    return entry.profile;
+  }
+
+  /**
+   * プロフィール情報をキャッシュに保存
+   */
+  private setCachedProfile(did: string, profile: ProfileInfo): void {
+    const entry: ProfileCacheEntry = {
+      profile,
+      expiredAt: Date.now() + this.cacheExpiry
+    };
+    this.profileCache.set(did, entry);
+  }
+
+  /**
+   * 基本プロフィール情報を取得（アバターキャッシュ用）
+   * @param did アカウントDID
+   */
+  async getProfile(did: string): Promise<ProfileServiceResult<ProfileInfo>> {
+    try {
+      // DIDバリデーション
+      if (!did || !did.startsWith('did:')) {
+        return {
+          success: false,
+          error: {
+            type: 'INVALID_DID',
+            message: 'Invalid DID format'
+          }
+        };
+      }
+
+      // キャッシュチェック
+      const cached = this.getCachedProfile(did);
+      if (cached) {
+        console.log(`🎭 [ProfileService] Profile cache hit for ${did}`);
+        return {
+          success: true,
+          data: cached
+        };
+      }
+
+      // アクティブアカウントのセッション情報を取得
+      const accountResult = await authService.getActiveAccount();
+      if (!accountResult.success || !accountResult.data?.session) {
+        return {
+          success: false,
+          error: {
+            type: 'AUTH_REQUIRED',
+            message: 'Active account session not found'
+          }
+        };
+      }
+
+      const { session, service } = accountResult.data;
+      const agent = new BskyAgent({ service: service || 'https://bsky.social' });
+      
+      // セッション復元
+      await agent.resumeSession(session);
+
+      console.log(`🎭 [ProfileService] Fetching profile for ${did}`);
+
+      // app.bsky.actor.getProfile API 呼び出し
+      const response = await agent.getProfile({ actor: did });
+      
+      if (!response.success) {
+        return {
+          success: false,
+          error: {
+            type: 'API_ERROR',
+            message: 'Failed to fetch profile'
+          }
+        };
+      }
+
+      const profile = response.data;
+      
+      // プロフィール情報の抽出
+      const profileInfo: ProfileInfo = {
+        did: profile.did,
+        handle: profile.handle,
+        displayName: profile.displayName,
+        avatar: profile.avatar,
+        description: profile.description,
+        lastUpdated: new Date()
+      };
+
+      // キャッシュに保存
+      this.setCachedProfile(did, profileInfo);
+
+      console.log(`🎭 [ProfileService] Profile fetched for ${did}:`, {
+        handle: profileInfo.handle,
+        displayName: profileInfo.displayName,
+        hasAvatar: !!profileInfo.avatar
+      });
+
+      return {
+        success: true,
+        data: profileInfo
+      };
+
+    } catch (error: any) {
+      console.error(`🎭 [ProfileService] Error fetching profile for ${did}:`, error);
+
+      // エラー種別の判定
+      let errorType: ProfileServiceError = 'API_ERROR';
+      let errorMessage = 'Unknown error occurred';
+
+      if (error.message?.includes('rate limit')) {
+        errorType = 'RATE_LIMITED';
+        errorMessage = 'Rate limit exceeded. Please try again later.';
+      } else if (error.message?.includes('network') || error.code === 'NETWORK_ERROR') {
+        errorType = 'NETWORK_ERROR';
+        errorMessage = 'Network error occurred. Please check your connection.';
+      } else if (error.status === 404 || error.message?.includes('not found')) {
+        errorType = 'PROFILE_NOT_FOUND';
+        errorMessage = 'Profile not found';
+      } else if (error.status === 401 || error.message?.includes('unauthorized')) {
+        errorType = 'AUTH_REQUIRED';
+        errorMessage = 'Authentication required';
+      }
+
+      return {
+        success: false,
+        error: {
+          type: errorType,
+          message: errorMessage
+        }
+      };
+    }
+  }
+
+  /**
+   * 複数プロフィール情報をバッチ取得（アバターキャッシュ用）
+   * @param dids アカウントDIDの配列
+   */
+  async getProfiles(dids: string[]): Promise<Array<{did: string; success: boolean; data?: ProfileInfo; error?: string}>> {
+    try {
+      // アクティブアカウントのセッション情報を取得
+      const accountResult = await authService.getActiveAccount();
+      if (!accountResult.success || !accountResult.data?.session) {
+        // 認証エラーの場合、全てのDIDに対してエラーを返す
+        return dids.map(did => ({
+          did,
+          success: false,
+          error: 'Active account session not found'
+        }));
+      }
+
+      const { session, service } = accountResult.data;
+      const agent = new BskyAgent({ service: service || 'https://bsky.social' });
+      
+      // セッション復元
+      await agent.resumeSession(session);
+
+      console.log(`🎭 [ProfileService] Batch fetching profiles for ${dids.length} DIDs`);
+
+      // キャッシュから取得できるものを分離
+      const results: Array<{did: string; success: boolean; data?: ProfileInfo; error?: string}> = [];
+      const needsFetch: string[] = [];
+
+      for (const did of dids) {
+        const cached = this.getCachedProfile(did);
+        if (cached) {
+          results.push({
+            did,
+            success: true,
+            data: cached
+          });
+        } else {
+          needsFetch.push(did);
+        }
+      }
+
+      // APIから取得が必要なDIDがある場合
+      if (needsFetch.length > 0) {
+        try {
+          // app.bsky.actor.getProfiles API 呼び出し（バッチ取得）
+          const response = await agent.getProfiles({ actors: needsFetch });
+          
+          if (response.success) {
+            // 成功したプロフィールを処理
+            for (const profile of response.data.profiles) {
+              const profileInfo: ProfileInfo = {
+                did: profile.did,
+                handle: profile.handle,
+                displayName: profile.displayName,
+                avatar: profile.avatar,
+                description: profile.description,
+                lastUpdated: new Date()
+              };
+
+              // キャッシュに保存
+              this.setCachedProfile(profile.did, profileInfo);
+
+              results.push({
+                did: profile.did,
+                success: true,
+                data: profileInfo
+              });
+            }
+
+            // 取得できなかったDIDがある場合はエラーとして追加
+            const fetchedDids = new Set(response.data.profiles.map(p => p.did));
+            for (const did of needsFetch) {
+              if (!fetchedDids.has(did)) {
+                results.push({
+                  did,
+                  success: false,
+                  error: 'Profile not found in batch response'
+                });
+              }
+            }
+          } else {
+            // バッチ取得が失敗した場合、個別取得にフォールバック
+            console.warn('🎭 [ProfileService] Batch fetch failed, falling back to individual requests');
+            
+            for (const did of needsFetch) {
+              try {
+                const individualResult = await this.getProfile(did);
+                if (individualResult.success && individualResult.data) {
+                  results.push({
+                    did,
+                    success: true,
+                    data: individualResult.data
+                  });
+                } else {
+                  results.push({
+                    did,
+                    success: false,
+                    error: individualResult.error?.message || 'Individual fetch failed'
+                  });
+                }
+              } catch (error) {
+                results.push({
+                  did,
+                  success: false,
+                  error: error instanceof Error ? error.message : 'Individual fetch error'
+                });
+              }
+            }
+          }
+        } catch (error) {
+          console.error('🎭 [ProfileService] Batch fetch error:', error);
+          
+          // バッチ取得エラーの場合、全ての未取得DIDにエラーを設定
+          for (const did of needsFetch) {
+            results.push({
+              did,
+              success: false,
+              error: error instanceof Error ? error.message : 'Batch fetch failed'
+            });
+          }
+        }
+      }
+
+      console.log(`🎭 [ProfileService] Batch fetch complete: ${results.filter(r => r.success).length}/${dids.length} successful`);
+
+      return results;
+
+    } catch (error: any) {
+      console.error('🎭 [ProfileService] Batch profile fetch error:', error);
+      
+      // 全体的なエラーの場合、全てのDIDに対してエラーを返す
+      return dids.map(did => ({
+        did,
+        success: false,
+        error: error instanceof Error ? error.message : 'Batch fetch failed'
+      }));
+    }
   }
 
   /**
@@ -215,10 +527,12 @@ export class ProfileService {
    */
   public clearCache(did?: string): void {
     if (did) {
-      this.cache.delete(did);
+      this.statsCache.delete(did);
+      this.profileCache.delete(did);
       console.log(`📊 [ProfileService] Cache cleared for ${did}`);
     } else {
-      this.cache.clear();
+      this.statsCache.clear();
+      this.profileCache.clear();
       console.log(`📊 [ProfileService] All cache cleared`);
     }
   }
@@ -226,18 +540,34 @@ export class ProfileService {
   /**
    * キャッシュサイズを取得（デバッグ用）
    */
-  public getCacheSize(): number {
-    return this.cache.size;
+  public getCacheSize(): { stats: number; profiles: number; total: number } {
+    return {
+      stats: this.statsCache.size,
+      profiles: this.profileCache.size,
+      total: this.statsCache.size + this.profileCache.size
+    };
   }
 
   /**
-   * キャッシュの状態を取得（デバッグ用）
+   * 統計キャッシュの状態を取得（デバッグ用）
    */
-  public getCacheInfo(): Array<{ did: string; lastUpdated: Date; expiresIn: number }> {
+  public getStatsCacheInfo(): Array<{ did: string; lastUpdated: Date; expiresIn: number }> {
     const now = Date.now();
-    return Array.from(this.cache.entries()).map(([did, entry]) => ({
+    return Array.from(this.statsCache.entries()).map(([did, entry]) => ({
       did,
       lastUpdated: entry.stats.lastUpdated,
+      expiresIn: Math.max(0, entry.expiredAt - now)
+    }));
+  }
+
+  /**
+   * プロフィールキャッシュの状態を取得（デバッグ用）
+   */
+  public getProfileCacheInfo(): Array<{ did: string; lastUpdated: Date; expiresIn: number }> {
+    const now = Date.now();
+    return Array.from(this.profileCache.entries()).map(([did, entry]) => ({
+      did,
+      lastUpdated: entry.profile.lastUpdated,
       expiresIn: Math.max(0, entry.expiredAt - now)
     }));
   }

--- a/moodeSky/src/lib/stores/avatarCache.svelte.ts
+++ b/moodeSky/src/lib/stores/avatarCache.svelte.ts
@@ -314,7 +314,7 @@ class AvatarCacheStore {
         const batchResults = await this.fetchProfilesBatch(batch);
         
         for (const result of batchResults) {
-          if (result.success) {
+          if (result.success && result.data) {
             this.setCache(result.did, result.data);
             results.set(result.did, result.data);
           } else {

--- a/moodeSky/src/lib/stores/avatarCache.svelte.ts
+++ b/moodeSky/src/lib/stores/avatarCache.svelte.ts
@@ -1,0 +1,573 @@
+import type { 
+  CachedAvatarInfo, 
+  AccountProfileRequest, 
+  AvatarCacheConfig, 
+  CacheStats, 
+  AvatarFetchResult,
+  BatchFetchResult 
+} from '$lib/types/avatarCache.js';
+import { authService } from '$lib/services/authStore.js';
+import { profileService } from '$lib/services/profileService.js';
+
+/**
+ * グローバルアバターキャッシュストア (Svelte 5 runes)
+ * 
+ * マルチデッキ環境でのアバター取得を効率化
+ * - DIDベースのキャッシュ管理
+ * - バッチ取得による API 効率化
+ * - TTL ベースの自動更新
+ * - メモリ使用量制限
+ */
+class AvatarCacheStore {
+  // ===================================================================
+  // 設定
+  // ===================================================================
+  
+  private readonly config: AvatarCacheConfig = {
+    ttl: 30 * 60 * 1000,          // 30分
+    staleTtl: 2 * 60 * 60 * 1000, // 2時間  
+    maxCacheSize: 1000,           // 最大1000アカウント
+    batchSize: 25,                // 一度に25アカウントまで取得
+    maxRetries: 3,                // 最大3回リトライ
+    retryDelay: 1000              // 1秒間隔
+  };
+
+  // ===================================================================
+  // 状態管理 (Svelte 5 runes)
+  // ===================================================================
+  
+  /** メインキャッシュ（DID -> アバター情報） */
+  private cache = $state<Map<string, CachedAvatarInfo>>(new Map());
+  
+  /** 現在取得中のDIDセット */
+  private fetchingDids = $state<Set<string>>(new Set());
+  
+  /** バッチ取得キュー */
+  private batchQueue = $state<Set<string>>(new Set());
+  
+  /** 統計情報 */
+  private stats = $state<CacheStats>({
+    totalCached: 0,
+    hitRate: 0,
+    missCount: 0,
+    errorCount: 0,
+    lastCleanup: Date.now()
+  });
+  
+  /** 初期化状態 */
+  private isInitialized = $state(false);
+
+  // ===================================================================
+  // 算出プロパティ
+  // ===================================================================
+  
+  /** 現在のキャッシュサイズ */
+  get cacheSize(): number {
+    return this.cache.size;
+  }
+  
+  /** 統計情報（読み取り専用） */
+  get statistics(): CacheStats {
+    return { ...this.stats };
+  }
+  
+  /** 初期化完了状態 */
+  get initialized(): boolean {
+    return this.isInitialized;
+  }
+
+  // ===================================================================
+  // 公開メソッド
+  // ===================================================================
+  
+  /**
+   * キャッシュストアを初期化
+   */
+  async initialize(): Promise<void> {
+    if (this.isInitialized) return;
+    
+    try {
+      console.log('🎭 [AvatarCache] Initializing avatar cache system...');
+      
+      // 既存のアカウント情報からキャッシュを初期構築
+      await this.initializeCacheFromAccounts();
+      
+      // 定期クリーンアップタスクを開始
+      this.startCleanupTask();
+      
+      this.isInitialized = true;
+      console.log(`🎭 [AvatarCache] Initialized with ${this.cacheSize} cached avatars`);
+      
+    } catch (error) {
+      console.error('🎭 [AvatarCache] Initialization failed:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * 単一アカウントのアバター情報を取得
+   */
+  async getAvatar(did: string): Promise<AvatarFetchResult> {
+    // キャッシュから確認
+    const cached = this.getCachedAvatar(did);
+    if (cached && this.isCacheValid(cached)) {
+      this.updateHitRate(true);
+      return {
+        success: true,
+        data: cached,
+        fromCache: true
+      };
+    }
+
+    // ステイルなキャッシュがある場合は返しつつ、バックグラウンドで更新
+    if (cached && this.isCacheStale(cached)) {
+      this.scheduleBackgroundFetch(did);
+      this.updateHitRate(true);
+      return {
+        success: true,
+        data: cached,
+        fromCache: true
+      };
+    }
+
+    // キャッシュミス - 取得をスケジュール
+    this.updateHitRate(false);
+    return await this.fetchAvatar(did);
+  }
+
+  /**
+   * 複数アカウントのアバター情報をバッチ取得
+   */
+  async getAvatars(dids: string[]): Promise<Map<string, AvatarFetchResult>> {
+    const results = new Map<string, AvatarFetchResult>();
+    const needsFetch: string[] = [];
+    
+    // キャッシュから取得可能なものを抽出
+    for (const did of dids) {
+      const cached = this.getCachedAvatar(did);
+      if (cached && this.isCacheValid(cached)) {
+        results.set(did, {
+          success: true,
+          data: cached,
+          fromCache: true
+        });
+        this.updateHitRate(true);
+      } else {
+        needsFetch.push(did);
+        this.updateHitRate(false);
+      }
+    }
+
+    // 取得が必要なものをバッチ処理
+    if (needsFetch.length > 0) {
+      const batchResults = await this.batchFetchAvatars(needsFetch);
+      
+      for (const [did, avatarInfo] of batchResults.results) {
+        results.set(did, {
+          success: true,
+          data: avatarInfo,
+          fromCache: false
+        });
+      }
+      
+      // エラーが発生したものも結果に含める
+      for (const { did, error } of batchResults.errors) {
+        results.set(did, {
+          success: false,
+          error,
+          fromCache: false
+        });
+      }
+    }
+
+    return results;
+  }
+
+  /**
+   * キャッシュをクリア
+   */
+  clearCache(): void {
+    console.log('🎭 [AvatarCache] Clearing cache...');
+    this.cache.clear();
+    this.fetchingDids.clear();
+    this.batchQueue.clear();
+    this.stats.totalCached = 0;
+    this.stats.lastCleanup = Date.now();
+  }
+
+  /**
+   * 特定のアカウントのキャッシュを無効化
+   */
+  invalidateAvatar(did: string): void {
+    console.log(`🎭 [AvatarCache] Invalidating cache for DID: ${did}`);
+    this.cache.delete(did);
+    this.fetchingDids.delete(did);
+    this.batchQueue.delete(did);
+  }
+
+  /**
+   * 手動でアバター情報を更新
+   */
+  async refreshAvatar(did: string): Promise<AvatarFetchResult> {
+    this.invalidateAvatar(did);
+    return await this.fetchAvatar(did);
+  }
+
+  // ===================================================================
+  // プライベートメソッド
+  // ===================================================================
+
+  /**
+   * キャッシュされたアバター情報を取得
+   */
+  private getCachedAvatar(did: string): CachedAvatarInfo | null {
+    return this.cache.get(did) || null;
+  }
+
+  /**
+   * キャッシュが有効かチェック
+   */
+  private isCacheValid(cached: CachedAvatarInfo): boolean {
+    const now = Date.now();
+    return (now - cached.cachedAt) < this.config.ttl && cached.status === 'success';
+  }
+
+  /**
+   * キャッシュがステイル状態かチェック
+   */
+  private isCacheStale(cached: CachedAvatarInfo): boolean {
+    const now = Date.now();
+    return (now - cached.cachedAt) > this.config.ttl && 
+           (now - cached.cachedAt) < this.config.staleTtl && 
+           cached.status === 'success';
+  }
+
+  /**
+   * 単一アバターを取得
+   */
+  private async fetchAvatar(did: string): Promise<AvatarFetchResult> {
+    if (this.fetchingDids.has(did)) {
+      // すでに取得中の場合は待機
+      return await this.waitForFetch(did);
+    }
+
+    this.fetchingDids.add(did);
+
+    try {
+      // AT Protocol APIを使用してプロフィール取得
+      const profile = await this.fetchProfileFromApi(did);
+      
+      const avatarInfo: CachedAvatarInfo = {
+        did,
+        handle: profile.handle || did,
+        displayName: profile.displayName,
+        avatarUrl: profile.avatar,
+        cachedAt: Date.now(),
+        lastUpdated: Date.now(),
+        status: 'success'
+      };
+
+      this.setCache(did, avatarInfo);
+      
+      return {
+        success: true,
+        data: avatarInfo,
+        fromCache: false
+      };
+
+    } catch (error) {
+      console.error(`🎭 [AvatarCache] Failed to fetch avatar for ${did}:`, error);
+      
+      const errorInfo: CachedAvatarInfo = {
+        did,
+        handle: did,
+        cachedAt: Date.now(),
+        lastUpdated: Date.now(),
+        status: 'error',
+        error: error instanceof Error ? error.message : 'Unknown error'
+      };
+
+      this.setCache(did, errorInfo);
+      this.stats.errorCount++;
+
+      return {
+        success: false,
+        error: errorInfo.error,
+        fromCache: false
+      };
+
+    } finally {
+      this.fetchingDids.delete(did);
+    }
+  }
+
+  /**
+   * バッチでアバター情報を取得
+   */
+  private async batchFetchAvatars(dids: string[]): Promise<BatchFetchResult> {
+    const batches = this.createBatches(dids, this.config.batchSize);
+    const results = new Map<string, CachedAvatarInfo>();
+    const errors: Array<{ did: string; error: string }> = [];
+    
+    for (const batch of batches) {
+      try {
+        const batchResults = await this.fetchProfilesBatch(batch);
+        
+        for (const result of batchResults) {
+          if (result.success) {
+            this.setCache(result.did, result.data);
+            results.set(result.did, result.data);
+          } else {
+            errors.push({ did: result.did, error: result.error || 'Unknown error' });
+            this.stats.errorCount++;
+          }
+        }
+        
+      } catch (error) {
+        console.error('🎭 [AvatarCache] Batch fetch failed:', error);
+        
+        // バッチ全体が失敗した場合、個別エラーとして記録
+        for (const did of batch) {
+          errors.push({ 
+            did, 
+            error: error instanceof Error ? error.message : 'Batch fetch failed' 
+          });
+        }
+      }
+      
+      // バッチ間で少し待機（レート制限対策）
+      if (batches.length > 1) {
+        await new Promise(resolve => setTimeout(resolve, 100));
+      }
+    }
+
+    return {
+      successCount: results.size,
+      errorCount: errors.length,
+      results,
+      errors
+    };
+  }
+
+  /**
+   * APIからプロフィール情報を取得
+   */
+  private async fetchProfileFromApi(did: string): Promise<any> {
+    try {
+      const result = await profileService.getProfile(did);
+      
+      if (!result.success || !result.data) {
+        throw new Error(result.error?.message || 'Profile fetch failed');
+      }
+
+      return {
+        handle: result.data.handle,
+        displayName: result.data.displayName,
+        avatar: result.data.avatar
+      };
+    } catch (error) {
+      console.error(`🎭 [AvatarCache] ProfileService fetch failed for ${did}:`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * バッチでプロフィール情報を取得
+   */
+  private async fetchProfilesBatch(dids: string[]): Promise<Array<{did: string; success: boolean; data?: CachedAvatarInfo; error?: string}>> {
+    try {
+      const batchResults = await profileService.getProfiles(dids);
+      
+      return batchResults.map(result => {
+        if (result.success && result.data) {
+          return {
+            did: result.did,
+            success: true,
+            data: {
+              did: result.data.did,
+              handle: result.data.handle,
+              displayName: result.data.displayName,
+              avatarUrl: result.data.avatar,
+              cachedAt: Date.now(),
+              lastUpdated: Date.now(),
+              status: 'success' as const
+            }
+          };
+        } else {
+          return {
+            did: result.did,
+            success: false,
+            error: result.error || 'Profile fetch failed'
+          };
+        }
+      });
+    } catch (error) {
+      console.error(`🎭 [AvatarCache] Batch profile fetch failed:`, error);
+      
+      // バッチ全体が失敗した場合は全てエラーとして返す
+      return dids.map(did => ({
+        did,
+        success: false,
+        error: error instanceof Error ? error.message : 'Batch fetch failed'
+      }));
+    }
+  }
+
+  /**
+   * 配列を指定サイズのバッチに分割
+   */
+  private createBatches<T>(array: T[], batchSize: number): T[][] {
+    const batches: T[][] = [];
+    for (let i = 0; i < array.length; i += batchSize) {
+      batches.push(array.slice(i, i + batchSize));
+    }
+    return batches;
+  }
+
+  /**
+   * キャッシュに保存
+   */
+  private setCache(did: string, avatarInfo: CachedAvatarInfo): void {
+    // キャッシュサイズ制限チェック
+    if (this.cache.size >= this.config.maxCacheSize && !this.cache.has(did)) {
+      this.cleanupOldestCache();
+    }
+    
+    this.cache.set(did, avatarInfo);
+    this.stats.totalCached = this.cache.size;
+  }
+
+  /**
+   * 最も古いキャッシュを削除
+   */
+  private cleanupOldestCache(): void {
+    let oldestTime = Date.now();
+    let oldestDid = '';
+    
+    for (const [did, info] of this.cache) {
+      if (info.cachedAt < oldestTime) {
+        oldestTime = info.cachedAt;
+        oldestDid = did;
+      }
+    }
+    
+    if (oldestDid) {
+      this.cache.delete(oldestDid);
+      console.log(`🎭 [AvatarCache] Removed oldest cache entry: ${oldestDid}`);
+    }
+  }
+
+  /**
+   * ヒット率を更新
+   */
+  private updateHitRate(hit: boolean): void {
+    const totalRequests = this.stats.missCount + (this.stats.hitRate * this.stats.totalCached || 0);
+    if (!hit) {
+      this.stats.missCount++;
+    }
+    const newTotalRequests = totalRequests + 1;
+    const hits = newTotalRequests - this.stats.missCount;
+    this.stats.hitRate = hits / newTotalRequests;
+  }
+
+  /**
+   * バックグラウンドで取得をスケジュール
+   */
+  private scheduleBackgroundFetch(did: string): void {
+    setTimeout(() => {
+      this.fetchAvatar(did).catch(error => {
+        console.warn(`🎭 [AvatarCache] Background fetch failed for ${did}:`, error);
+      });
+    }, 100);
+  }
+
+  /**
+   * 取得完了を待機
+   */
+  private async waitForFetch(did: string): Promise<AvatarFetchResult> {
+    const maxWait = 10000; // 最大10秒待機
+    const startTime = Date.now();
+    
+    while (this.fetchingDids.has(did) && (Date.now() - startTime) < maxWait) {
+      await new Promise(resolve => setTimeout(resolve, 100));
+    }
+    
+    const cached = this.getCachedAvatar(did);
+    if (cached) {
+      return {
+        success: cached.status === 'success',
+        data: cached,
+        error: cached.error,
+        fromCache: true
+      };
+    }
+    
+    return {
+      success: false,
+      error: 'Fetch timeout',
+      fromCache: false
+    };
+  }
+
+  /**
+   * 既存アカウントからキャッシュを初期構築
+   */
+  private async initializeCacheFromAccounts(): Promise<void> {
+    try {
+      const result = await authService.getAllAccounts();
+      if (result.success && result.data) {
+        for (const account of result.data) {
+          const avatarInfo: CachedAvatarInfo = {
+            did: account.profile.did,
+            handle: account.profile.handle,
+            displayName: account.profile.displayName,
+            avatarUrl: account.profile.avatar,
+            cachedAt: Date.now(),
+            lastUpdated: Date.now(),
+            status: 'success'
+          };
+          this.cache.set(account.profile.did, avatarInfo);
+        }
+        this.stats.totalCached = this.cache.size;
+        console.log(`🎭 [AvatarCache] Pre-cached ${this.cache.size} account avatars`);
+      }
+    } catch (error) {
+      console.warn('🎭 [AvatarCache] Failed to initialize cache from accounts:', error);
+    }
+  }
+
+  /**
+   * 定期クリーンアップタスクを開始
+   */
+  private startCleanupTask(): void {
+    // 5分おきにクリーンアップを実行
+    setInterval(() => {
+      this.cleanupExpiredCache();
+    }, 5 * 60 * 1000);
+  }
+
+  /**
+   * 期限切れキャッシュをクリーンアップ
+   */
+  private cleanupExpiredCache(): void {
+    const now = Date.now();
+    let removedCount = 0;
+    
+    for (const [did, info] of this.cache) {
+      if ((now - info.cachedAt) > this.config.staleTtl) {
+        this.cache.delete(did);
+        removedCount++;
+      }
+    }
+    
+    this.stats.totalCached = this.cache.size;
+    this.stats.lastCleanup = now;
+    
+    if (removedCount > 0) {
+      console.log(`🎭 [AvatarCache] Cleaned up ${removedCount} expired cache entries`);
+    }
+  }
+}
+
+// シングルトンインスタンス
+export const avatarCache = new AvatarCacheStore();

--- a/moodeSky/src/lib/types/avatarCache.ts
+++ b/moodeSky/src/lib/types/avatarCache.ts
@@ -1,0 +1,96 @@
+/**
+ * グローバルアバターキャッシュシステムの型定義
+ * 
+ * 複数デッキでのアバター取得を効率化するためのキャッシュシステム
+ * 各アカウントのプロフィール情報をDIDベースでキャッシュ
+ */
+
+/**
+ * キャッシュされたアバター情報
+ */
+export interface CachedAvatarInfo {
+  /** アカウントDID（キー） */
+  did: string;
+  /** ハンドル名 */
+  handle: string;
+  /** 表示名 */
+  displayName?: string;
+  /** アバター画像URL */
+  avatarUrl?: string;
+  /** キャッシュ作成日時 */
+  cachedAt: number;
+  /** 最終更新日時 */
+  lastUpdated: number;
+  /** 取得状態 */
+  status: 'loading' | 'success' | 'error' | 'stale';
+  /** エラーメッセージ（エラー時） */
+  error?: string;
+}
+
+/**
+ * バッチ取得用のアカウント情報
+ */
+export interface AccountProfileRequest {
+  /** アカウントDID */
+  did: string;
+  /** ハンドル名（取得済みの場合） */
+  handle?: string;
+}
+
+/**
+ * アバターキャッシュの設定
+ */
+export interface AvatarCacheConfig {
+  /** キャッシュ有効期限（ミリ秒）デフォルト: 30分 */
+  ttl: number;
+  /** ステイル許容期間（ミリ秒）デフォルト: 2時間 */
+  staleTtl: number;
+  /** 最大キャッシュサイズ デフォルト: 1000 */
+  maxCacheSize: number;
+  /** バッチ取得のサイズ デフォルト: 25 */
+  batchSize: number;
+  /** 取得リトライ回数 デフォルト: 3 */
+  maxRetries: number;
+  /** リトライ間隔（ミリ秒）デフォルト: 1000 */
+  retryDelay: number;
+}
+
+/**
+ * キャッシュ統計情報
+ */
+export interface CacheStats {
+  /** 総キャッシュ数 */
+  totalCached: number;
+  /** ヒット率 */
+  hitRate: number;
+  /** ミス数 */
+  missCount: number;
+  /** エラー数 */
+  errorCount: number;
+  /** 最終更新日時 */
+  lastCleanup: number;
+}
+
+/**
+ * アバター取得結果
+ */
+export interface AvatarFetchResult {
+  success: boolean;
+  data?: CachedAvatarInfo;
+  error?: string;
+  fromCache: boolean;
+}
+
+/**
+ * バッチ取得結果
+ */
+export interface BatchFetchResult {
+  /** 成功した取得数 */
+  successCount: number;
+  /** 失敗した取得数 */
+  errorCount: number;
+  /** 取得結果の詳細 */
+  results: Map<string, CachedAvatarInfo>;
+  /** 発生したエラー */
+  errors: Array<{ did: string; error: string }>;
+}

--- a/moodeSky/src/routes/deck/+page.svelte
+++ b/moodeSky/src/routes/deck/+page.svelte
@@ -9,6 +9,7 @@
   import type { Account } from '$lib/types/auth.js';
   import { useTranslation } from '$lib/utils/reactiveTranslation.svelte.js';
   import { deckStore } from '$lib/deck/store.svelte.js';
+  import { avatarCache } from '$lib/stores/avatarCache.svelte.js';
   
   
   // リアクティブ翻訳システム
@@ -103,7 +104,12 @@
           columns: deckStore.columns
         });
         
-        await deckStore.initialize(activeAccount.profile.handle);
+        await deckStore.initialize(activeAccount.profile.did);
+        
+        // アバターキャッシュシステムを初期化
+        console.log('🔍 [DEBUG] Initializing avatar cache...');
+        await avatarCache.initialize();
+        console.log('🔍 [DEBUG] Avatar cache initialized successfully');
         
         console.log('🔍 [DEBUG] DeckStore state after init:', {
           isInitialized: deckStore.isInitialized,
@@ -127,7 +133,7 @@
           
           try {
             const newColumn = await deckStore.addColumn(
-              activeAccount.profile.handle,
+              activeAccount.profile.did,
               'home',
               {
                 title: t('navigation.home'),
@@ -162,7 +168,7 @@
             console.log('🚨 [FAILSAFE] No columns found after 3 seconds, forcing default column creation');
             try {
               const failsafeColumn = await deckStore.addColumn(
-                activeAccount.profile.handle,
+                activeAccount.profile.did,
                 'home',
                 {
                   title: t('navigation.home'),
@@ -235,7 +241,7 @@
       
       // 非同期でデフォルトカラムを作成
       deckStore.addColumn(
-        activeAccount.profile.handle,
+        activeAccount.profile.did,
         'home',
         {
           title: t('navigation.home'),
@@ -288,7 +294,7 @@
   {console.log('🔍 [DEBUG] Rendering main deck layout with account:', activeAccount)}
   <div class="h-screen flex flex-col bg-themed">
     <!-- ナビゲーション（レスポンシブ制御は Navigation 内部で実施） -->
-    <Navigation {currentPath} accountId={activeAccount.profile.handle} onAddDeck={handleOpenAddDeckModal} />
+    <Navigation {currentPath} accountId={activeAccount.profile.did} onAddDeck={handleOpenAddDeckModal} />
     
     <!-- モバイル用デッキタブは Navigation.svelte 内で管理 -->
     
@@ -298,6 +304,7 @@
       <div class="deck-content-wrapper">
         <DeckContainer 
           accountId={activeAccount.profile.handle}
+          activeAccount={activeAccount}
           className="h-full"
           {showAddDeckModal}
           onCloseAddDeckModal={handleCloseAddDeckModal}

--- a/moodeSky/src/routes/settings/components/DeckManagementSettings.svelte
+++ b/moodeSky/src/routes/settings/components/DeckManagementSettings.svelte
@@ -15,14 +15,13 @@
   import { authService } from '$lib/services/authStore.js';
   import type { Account } from '$lib/types/auth.js';
   import type { Column } from '$lib/deck/types.js';
-  import { useTranslation } from '$lib/utils/reactiveTranslation.svelte.js';
+  import * as m from '../../../paraglide/messages.js';
   import { message } from '@tauri-apps/plugin-dialog';
 
   // ===================================================================
   // 状態管理
   // ===================================================================
 
-  const { t } = useTranslation();
 
   let activeAccount = $state<Account | null>(null);
   let isLoading = $state(true);
@@ -82,7 +81,7 @@
       
       // 成功メッセージ表示
       await message(
-        `${t('settings.deckManagement.addSuccess').replace('{name}', column.settings.title)}`
+        m['settings.deckManagement.addSuccess']({ name: column.settings.title })
       );
       
       // ホーム画面に自動遷移
@@ -110,7 +109,7 @@
     try {
       // 削除確認ダイアログ
       await message(
-        `${t('settings.deckManagement.deleteConfirmation').replace('{name}', deckTitle)}`
+        m['settings.deckManagement.deleteConfirmation']({ name: deckTitle })
       );
 
       // 削除実行
@@ -118,12 +117,12 @@
       
       // 成功メッセージ
       await message(
-        `${t('settings.deckManagement.deleteSuccess').replace('{name}', deckTitle)}`
+        m['settings.deckManagement.deleteSuccess']({ name: deckTitle })
       );
     } catch (error) {
       console.error('🛠️ [DeckManagement] デッキ削除エラー:', error);
       await message(
-        t('settings.deckManagement.deleteError')
+        m['settings.deckManagement.deleteError']()
       );
     }
   }
@@ -141,10 +140,10 @@
   <div class="mb-6">
     <h2 class="text-themed text-2xl font-bold mb-2 flex items-center gap-3">
       <Icon icon={ICONS.DASHBOARD} size="lg" color="themed" />
-      {t('settings.deckManagement.title')}
+      {m['settings.deckManagement.title']()}
     </h2>
     <p class="text-secondary text-lg leading-relaxed">
-      {t('settings.deckManagement.description')}
+      {m['settings.deckManagement.description']()}
     </p>
   </div>
 
@@ -152,7 +151,7 @@
     <!-- ローディング状態 -->
     <div class="bg-card rounded-xl p-8 text-center">
       <div class="w-8 h-8 border-3 border-primary/30 border-t-primary rounded-full animate-spin mx-auto mb-4"></div>
-      <p class="text-themed opacity-80">{t('settings.deckManagement.loading')}</p>
+      <p class="text-themed opacity-80">{m['settings.deckManagement.loading']()}</p>
     </div>
   {:else}
     <!-- デッキ追加ボタン -->
@@ -162,7 +161,7 @@
         onclick={handleAddDeck}
       >
         <Icon icon={ICONS.ADD} size="md" class="text-[var(--color-background)]" />
-        {t('settings.deckManagement.addDeck')}
+        {m['settings.deckManagement.addDeck']()}
       </button>
     </div>
 
@@ -170,7 +169,7 @@
       <!-- デッキ一覧 -->
       <div class="space-y-4">
         <h3 class="text-themed text-xl font-semibold mb-4">
-          {t('settings.deckManagement.existingDecks')}
+          {m['settings.deckManagement.existingDecks']()}
         </h3>
         
         {#each columns as column (column.id)}
@@ -190,10 +189,10 @@
                     {column.settings.title}
                   </h4>
                   <p class="text-secondary text-sm">
-                    {t('settings.deckManagement.algorithm')}: {column.algorithm}
+                    {m['settings.deckManagement.algorithm']()}: {column.algorithm}
                   </p>
                   <p class="text-secondary text-xs">
-                    {t('settings.deckManagement.createdAt')}: {new Date(column.createdAt).toLocaleDateString()}
+                    {m['settings.deckManagement.createdAt']()}: {new Date(column.createdAt).toLocaleDateString()}
                   </p>
                 </div>
               </div>
@@ -203,14 +202,14 @@
                 <button
                   class="p-2 text-secondary hover:text-themed hover:bg-muted rounded-lg transition-all"
                   onclick={() => handleDeckSettings(column.id, column.settings.title)}
-                  title={t('settings.deckManagement.settings')}
+                  title={m['settings.deckManagement.settings']()}
                 >
                   <Icon icon={ICONS.SETTINGS} size="md" />
                 </button>
                 <button
                   class="p-2 text-error hover:text-error/80 hover:bg-error/10 rounded-lg transition-all"
                   onclick={() => handleDeleteDeck(column.id, column.settings.title)}
-                  title={t('settings.deckManagement.delete')}
+                  title={m['settings.deckManagement.delete']()}
                 >
                   <Icon icon={ICONS.DELETE} size="md" />
                 </button>
@@ -224,17 +223,17 @@
       <div class="bg-card rounded-xl p-12 text-center">
         <div class="text-6xl mb-6">🎛️</div>
         <h3 class="text-themed text-xl font-semibold mb-2">
-          {t('settings.deckManagement.noDecks')}
+          {m['settings.deckManagement.noDecks']()}
         </h3>
         <p class="text-secondary mb-6">
-          {t('settings.deckManagement.noDecksDescription')}
+          {m['settings.deckManagement.noDecksDescription']()}
         </p>
         <button
           class="button-primary px-6 py-3 text-lg font-medium flex items-center gap-3 mx-auto"
           onclick={handleAddDeck}
         >
           <Icon icon={ICONS.ADD} size="md" class="text-[var(--color-background)]" />
-          {t('settings.deckManagement.addFirstDeck')}
+          {m['settings.deckManagement.addFirstDeck']()}
         </button>
       </div>
     {/if}

--- a/moodeSky/src/routes/settings/components/DeckManagementSettings.svelte
+++ b/moodeSky/src/routes/settings/components/DeckManagementSettings.svelte
@@ -15,12 +15,14 @@
   import { authService } from '$lib/services/authStore.js';
   import type { Account } from '$lib/types/auth.js';
   import type { Column } from '$lib/deck/types.js';
-  import * as m from '../../../paraglide/messages.js';
+  import { useTranslation } from '$lib/utils/reactiveTranslation.svelte.js';
   import { message } from '@tauri-apps/plugin-dialog';
 
   // ===================================================================
   // 状態管理
   // ===================================================================
+
+  const { t } = useTranslation();
 
 
   let activeAccount = $state<Account | null>(null);
@@ -81,7 +83,7 @@
       
       // 成功メッセージ表示
       await message(
-        m['settings.deckManagement.addSuccess']({ name: column.settings.title })
+        `${t('settings.deckManagement.addSuccess').replace('{name}', column.settings.title)}`
       );
       
       // ホーム画面に自動遷移
@@ -109,7 +111,7 @@
     try {
       // 削除確認ダイアログ
       await message(
-        m['settings.deckManagement.deleteConfirmation']({ name: deckTitle })
+        `${t('settings.deckManagement.deleteConfirmation').replace('{name}', deckTitle)}`
       );
 
       // 削除実行
@@ -117,12 +119,12 @@
       
       // 成功メッセージ
       await message(
-        m['settings.deckManagement.deleteSuccess']({ name: deckTitle })
+        `${t('settings.deckManagement.deleteSuccess').replace('{name}', deckTitle)}`
       );
     } catch (error) {
       console.error('🛠️ [DeckManagement] デッキ削除エラー:', error);
       await message(
-        m['settings.deckManagement.deleteError']()
+        t('settings.deckManagement.deleteError')
       );
     }
   }
@@ -140,10 +142,10 @@
   <div class="mb-6">
     <h2 class="text-themed text-2xl font-bold mb-2 flex items-center gap-3">
       <Icon icon={ICONS.DASHBOARD} size="lg" color="themed" />
-      {m['settings.deckManagement.title']()}
+      {t('settings.deckManagement.title')}
     </h2>
     <p class="text-secondary text-lg leading-relaxed">
-      {m['settings.deckManagement.description']()}
+      {t('settings.deckManagement.description')}
     </p>
   </div>
 
@@ -151,7 +153,7 @@
     <!-- ローディング状態 -->
     <div class="bg-card rounded-xl p-8 text-center">
       <div class="w-8 h-8 border-3 border-primary/30 border-t-primary rounded-full animate-spin mx-auto mb-4"></div>
-      <p class="text-themed opacity-80">{m['settings.deckManagement.loading']()}</p>
+      <p class="text-themed opacity-80">{t('settings.deckManagement.loading')}</p>
     </div>
   {:else}
     <!-- デッキ追加ボタン -->
@@ -161,7 +163,7 @@
         onclick={handleAddDeck}
       >
         <Icon icon={ICONS.ADD} size="md" class="text-[var(--color-background)]" />
-        {m['settings.deckManagement.addDeck']()}
+        {t('settings.deckManagement.addDeck')}
       </button>
     </div>
 
@@ -169,7 +171,7 @@
       <!-- デッキ一覧 -->
       <div class="space-y-4">
         <h3 class="text-themed text-xl font-semibold mb-4">
-          {m['settings.deckManagement.existingDecks']()}
+          {t('settings.deckManagement.existingDecks')}
         </h3>
         
         {#each columns as column (column.id)}
@@ -189,10 +191,10 @@
                     {column.settings.title}
                   </h4>
                   <p class="text-secondary text-sm">
-                    {m['settings.deckManagement.algorithm']()}: {column.algorithm}
+                    {t('settings.deckManagement.algorithm')}: {column.algorithm}
                   </p>
                   <p class="text-secondary text-xs">
-                    {m['settings.deckManagement.createdAt']()}: {new Date(column.createdAt).toLocaleDateString()}
+                    {t('settings.deckManagement.createdAt')}: {new Date(column.createdAt).toLocaleDateString()}
                   </p>
                 </div>
               </div>
@@ -202,14 +204,14 @@
                 <button
                   class="p-2 text-secondary hover:text-themed hover:bg-muted rounded-lg transition-all"
                   onclick={() => handleDeckSettings(column.id, column.settings.title)}
-                  title={m['settings.deckManagement.settings']()}
+                  title={t('settings.deckManagement.settings')}
                 >
                   <Icon icon={ICONS.SETTINGS} size="md" />
                 </button>
                 <button
                   class="p-2 text-error hover:text-error/80 hover:bg-error/10 rounded-lg transition-all"
                   onclick={() => handleDeleteDeck(column.id, column.settings.title)}
-                  title={m['settings.deckManagement.delete']()}
+                  title={t('settings.deckManagement.delete')}
                 >
                   <Icon icon={ICONS.DELETE} size="md" />
                 </button>
@@ -223,17 +225,17 @@
       <div class="bg-card rounded-xl p-12 text-center">
         <div class="text-6xl mb-6">🎛️</div>
         <h3 class="text-themed text-xl font-semibold mb-2">
-          {m['settings.deckManagement.noDecks']()}
+          {t('settings.deckManagement.noDecks')}
         </h3>
         <p class="text-secondary mb-6">
-          {m['settings.deckManagement.noDecksDescription']()}
+          {t('settings.deckManagement.noDecksDescription')}
         </p>
         <button
           class="button-primary px-6 py-3 text-lg font-medium flex items-center gap-3 mx-auto"
           onclick={handleAddDeck}
         >
           <Icon icon={ICONS.ADD} size="md" class="text-[var(--color-background)]" />
-          {m['settings.deckManagement.addFirstDeck']()}
+          {t('settings.deckManagement.addFirstDeck')}
         </button>
       </div>
     {/if}

--- a/moodeSky/src/routes/settings/components/DeckManagementSettings.svelte
+++ b/moodeSky/src/routes/settings/components/DeckManagementSettings.svelte
@@ -15,14 +15,12 @@
   import { authService } from '$lib/services/authStore.js';
   import type { Account } from '$lib/types/auth.js';
   import type { Column } from '$lib/deck/types.js';
-  import { useTranslation } from '$lib/utils/reactiveTranslation.svelte.js';
+  import { m } from '../../../paraglide/messages.js';
   import { message } from '@tauri-apps/plugin-dialog';
 
   // ===================================================================
   // 状態管理
   // ===================================================================
-
-  const { t } = useTranslation();
 
 
   let activeAccount = $state<Account | null>(null);
@@ -83,7 +81,7 @@
       
       // 成功メッセージ表示
       await message(
-        `${t('settings.deckManagement.addSuccess').replace('{name}', column.settings.title)}`
+        m['settings.deckManagement.addSuccess']({ name: column.settings.title })
       );
       
       // ホーム画面に自動遷移
@@ -111,7 +109,7 @@
     try {
       // 削除確認ダイアログ
       await message(
-        `${t('settings.deckManagement.deleteConfirmation').replace('{name}', deckTitle)}`
+        m['settings.deckManagement.deleteConfirmation']({ name: deckTitle })
       );
 
       // 削除実行
@@ -119,12 +117,12 @@
       
       // 成功メッセージ
       await message(
-        `${t('settings.deckManagement.deleteSuccess').replace('{name}', deckTitle)}`
+        m['settings.deckManagement.deleteSuccess']({ name: deckTitle })
       );
     } catch (error) {
       console.error('🛠️ [DeckManagement] デッキ削除エラー:', error);
       await message(
-        t('settings.deckManagement.deleteError')
+        m['settings.deckManagement.deleteError']()
       );
     }
   }
@@ -142,10 +140,10 @@
   <div class="mb-6">
     <h2 class="text-themed text-2xl font-bold mb-2 flex items-center gap-3">
       <Icon icon={ICONS.DASHBOARD} size="lg" color="themed" />
-      {t('settings.deckManagement.title')}
+      {m['settings.deckManagement.title']()}
     </h2>
     <p class="text-secondary text-lg leading-relaxed">
-      {t('settings.deckManagement.description')}
+      {m['settings.deckManagement.description']()}
     </p>
   </div>
 
@@ -153,7 +151,7 @@
     <!-- ローディング状態 -->
     <div class="bg-card rounded-xl p-8 text-center">
       <div class="w-8 h-8 border-3 border-primary/30 border-t-primary rounded-full animate-spin mx-auto mb-4"></div>
-      <p class="text-themed opacity-80">{t('settings.deckManagement.loading')}</p>
+      <p class="text-themed opacity-80">{m['settings.deckManagement.loading']()}</p>
     </div>
   {:else}
     <!-- デッキ追加ボタン -->
@@ -163,7 +161,7 @@
         onclick={handleAddDeck}
       >
         <Icon icon={ICONS.ADD} size="md" class="text-[var(--color-background)]" />
-        {t('settings.deckManagement.addDeck')}
+        {m['settings.deckManagement.addDeck']()}
       </button>
     </div>
 
@@ -171,7 +169,7 @@
       <!-- デッキ一覧 -->
       <div class="space-y-4">
         <h3 class="text-themed text-xl font-semibold mb-4">
-          {t('settings.deckManagement.existingDecks')}
+          {m['settings.deckManagement.existingDecks']()}
         </h3>
         
         {#each columns as column (column.id)}
@@ -191,10 +189,10 @@
                     {column.settings.title}
                   </h4>
                   <p class="text-secondary text-sm">
-                    {t('settings.deckManagement.algorithm')}: {column.algorithm}
+                    {m['settings.deckManagement.algorithm']()}: {column.algorithm}
                   </p>
                   <p class="text-secondary text-xs">
-                    {t('settings.deckManagement.createdAt')}: {new Date(column.createdAt).toLocaleDateString()}
+                    {m['settings.deckManagement.createdAt']()}: {new Date(column.createdAt).toLocaleDateString()}
                   </p>
                 </div>
               </div>
@@ -204,14 +202,14 @@
                 <button
                   class="p-2 text-secondary hover:text-themed hover:bg-muted rounded-lg transition-all"
                   onclick={() => handleDeckSettings(column.id, column.settings.title)}
-                  title={t('settings.deckManagement.settings')}
+                  title={m['settings.deckManagement.settings']()}
                 >
                   <Icon icon={ICONS.SETTINGS} size="md" />
                 </button>
                 <button
                   class="p-2 text-error hover:text-error/80 hover:bg-error/10 rounded-lg transition-all"
                   onclick={() => handleDeleteDeck(column.id, column.settings.title)}
-                  title={t('settings.deckManagement.delete')}
+                  title={m['settings.deckManagement.delete']()}
                 >
                   <Icon icon={ICONS.DELETE} size="md" />
                 </button>
@@ -225,17 +223,17 @@
       <div class="bg-card rounded-xl p-12 text-center">
         <div class="text-6xl mb-6">🎛️</div>
         <h3 class="text-themed text-xl font-semibold mb-2">
-          {t('settings.deckManagement.noDecks')}
+          {m['settings.deckManagement.noDecks']()}
         </h3>
         <p class="text-secondary mb-6">
-          {t('settings.deckManagement.noDecksDescription')}
+          {m['settings.deckManagement.noDecksDescription']()}
         </p>
         <button
           class="button-primary px-6 py-3 text-lg font-medium flex items-center gap-3 mx-auto"
           onclick={handleAddDeck}
         >
           <Icon icon={ICONS.ADD} size="md" class="text-[var(--color-background)]" />
-          {t('settings.deckManagement.addFirstDeck')}
+          {m['settings.deckManagement.addFirstDeck']()}
         </button>
       </div>
     {/if}

--- a/moodeSky/vite.config.js
+++ b/moodeSky/vite.config.js
@@ -14,6 +14,7 @@ export default defineConfig(async () => ({
         }
     },
 
+
     // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
     //
     // 1. prevent Vite from obscuring rust errors


### PR DESCRIPTION
## 🐛 問題

スマートフォン版でデッキ追加モーダルの1画面目→2画面目に遷移すると、外側の余白が2倍になりモーダルが小さく見える問題。

### 根本原因
- **AddDeckModal**: `size="lg"` (max-w-4xl)
- **FeedConfigModal**: `size="xl"` (max-w-6xl)

この差異により、画面遷移時にモーダルサイズが変化し、ユーザーに混乱を与えていました。

## 🔧 修正内容

### 1. Modal.svelte - レスポンシブサイズ対応
```typescript
// Before
case 'lg': return 'max-w-4xl';
case 'xl': return 'max-w-6xl';

// After  
case 'lg': return 'max-w-[calc(100vw-1rem)] sm:max-w-4xl';
case 'xl': return 'max-w-[calc(100vw-1rem)] sm:max-w-6xl';
```

### 2. モバイル最適化パディング
```typescript
// Before
p-4

// After
p-2 sm:p-4
```

### 3. モーダルサイズの統一
- FeedConfigModal: `size="xl"` → `size="lg"`
- 一貫したユーザー体験を提供

## ✅ 効果

- [x] スマートフォンでモーダルサイズが一貫
- [x] 画面遷移時の違和感を解消
- [x] モバイル最適化されたパディング
- [x] デスクトップ表示に影響なし

## 📱 テスト対象

- [ ] iPhone/Android実機での動作確認
- [ ] 画面回転時の表示確認
- [ ] タブレット端末での表示確認
- [ ] デスクトップでの後退確認なし

## 🎯 UX改善

ユーザーがデッキ追加フローを進める際に、視覚的な一貫性を保ち、迷いなく操作できるようになりました。

🤖 Generated with [Claude Code](https://claude.ai/code)