### PR TITLE
fix: PostCardのdisplayName表示とレイアウトを修正

### DIFF
--- a/moodeSky/src/lib/components/PostCard.svelte
+++ b/moodeSky/src/lib/components/PostCard.svelte
@@ -29,9 +29,9 @@
     }
   });
   
-  // 表示名の決定（displayName > handle）
-  const authorDisplayName = $derived(
-    post.author.displayName || `@${post.author.handle}`
+  // displayNameの有効性チェック
+  const hasValidDisplayName = $derived(
+    post.author.displayName && post.author.displayName.trim() !== ''
   );
 </script>
 
@@ -50,23 +50,28 @@
     
     <!-- 作者情報と日時 -->
     <div class="flex-1 min-w-0">
-      <div class="flex items-center gap-2 flex-wrap">
-        <!-- 表示名 -->
-        <h3 class="font-semibold text-themed text-sm truncate">
-          {authorDisplayName}
-        </h3>
-        
-        <!-- ハンドル -->
-        {#if post.author.displayName}
-          <span class="text-secondary text-sm truncate">
-            @{post.author.handle}
-          </span>
+      <!-- 1行目: 表示名と日時 (displayNameが有効な場合のみ) -->
+      {#if hasValidDisplayName}
+        <div class="flex items-center justify-between gap-2">
+          <h3 class="font-semibold text-themed text-sm truncate">
+            {post.author.displayName}
+          </h3>
+          <time class="text-secondary text-sm flex-shrink-0" datetime={post.createdAt}>
+            {formatDate()}
+          </time>
+        </div>
+      {/if}
+      
+      <!-- 2行目: ハンドル -->
+      <div class="flex items-center gap-2">
+        <span class="text-secondary text-sm truncate">
+          @{post.author.handle}
+        </span>
+        {#if !hasValidDisplayName}
+          <time class="text-secondary text-sm flex-shrink-0" datetime={post.createdAt}>
+            {formatDate()}
+          </time>
         {/if}
-        
-        <!-- 日時 -->
-        <time class="text-secondary text-sm flex-shrink-0" datetime={post.createdAt}>
-          {formatDate}
-        </time>
       </div>
     </div>
   </header>


### PR DESCRIPTION
## 🎯 Summary
PostCardコンポーネントのdisplayName表示ロジックとレイアウトを改善し、ユーザビリティを向上させました。

## 🔧 変更内容

### Before
- displayNameが空/nullでも表示される問題
- 一行構成で情報が密集
- formatDate関数がそのまま表示される不具合

### After  
- displayNameの有効性を適切にチェック
- 二行構成で読みやすいレイアウト
- 正しい日時フォーマット表示

## 📋 具体的な修正

### 1. 条件分岐ロジックの改善
```javascript
// Before
const authorDisplayName = $derived(
  post.author.displayName || `@${post.author.handle}`
);

// After
const hasValidDisplayName = $derived(
  post.author.displayName && post.author.displayName.trim() \!== ''
);
```

### 2. レイアウト構造の変更
- **displayNameがある場合**: 1行目にdisplayName + 日時、2行目にhandle
- **displayNameがない場合**: 1行目にhandle + 日時

### 3. 関数呼び出し修正
- `{formatDate}` → `{formatDate()}` でSvelteの関数表示問題を解決

## 🧪 Test Cases
- [x] displayNameがある投稿で二行表示を確認
- [x] displayNameがない投稿で一行表示を確認  
- [x] 空文字/null displayNameで適切に非表示になることを確認
- [x] 日時が正しく表示されることを確認
- [x] TypeScriptエラーがないことを確認

## 📱 UI/UX改善
- より構造化された読みやすいレイアウト
- displayNameの有無に関わらず一貫した表示
- 適切な情報階層の実現

## 🔍 Code Quality
- Svelte 5のrunesを適切に使用
- 明確な条件分岐ロジック
- 適切なコメント配置
- プロジェクトのコーディング規約に準拠

🤖 Generated with [Claude Code](https://claude.ai/code)