### PR TITLE
feat: ポストアクションボタンと黄金比ギャップシステムを実装

### DIFF
--- a/moodeSky/src/lib/components/PostCard.svelte
+++ b/moodeSky/src/lib/components/PostCard.svelte
@@ -1,19 +1,41 @@
 <!--
   PostCard.svelte
   シンプルなポスト表示カード
-  段階的実装: 作者名、テキスト、日時のみ
+  段階的実装: 作者名、テキスト、日時、アクションボタン
 -->
 <script lang="ts">
   import Avatar from './Avatar.svelte';
+  import PostActionButton from './post/PostActionButton.svelte';
   import { formatRelativeTime, formatAbsoluteTime } from '$lib/utils/relativeTime.js';
+  import { ICONS } from '$lib/types/icon.js';
   import type { SimplePost } from '$lib/types/post.js';
+  import type { ColumnWidth } from '$lib/deck/types.js';
   
   interface Props {
     post: SimplePost;
     class?: string;
+    columnWidth?: ColumnWidth;
   }
   
-  const { post, class: className = '' }: Props = $props();
+  const { post, class: className = '', columnWidth }: Props = $props();
+
+  // デッキサイズに応じたアクションボタンのギャップクラスを計算
+  // 黄金比・フィボナッチ数列を意識した美しい配置
+  function getActionButtonGap(columnWidth?: ColumnWidth): string {
+    if (!columnWidth) return 'gap-4'; // デフォルト（現在の値）
+    
+    const gapMap: Record<ColumnWidth, string> = {
+      'xxs': 'gap-2',     // 8px (2.9%) - 機能性重視の最小サイズ
+      'xs': 'gap-6',      // 24px (7.5%) - 大幅増加でインパクト
+      'small': 'gap-12',  // 48px (12.6%) - 黄金比的増加
+      'medium': 'gap-16', // 64px (14.2%) - 継続的な美しい増加
+      'large': 'gap-20',  // 80px (15.4%) - 劇的な余白増加
+      'xl': 'gap-28',     // 112px (18.7%) - さらに豊かな余白
+      'xxl': 'gap-40'     // 160px (22.2%) - 最大級の余白
+    };
+    
+    return gapMap[columnWidth] || 'gap-4';
+  }
   
   // 投稿日時の相対時間表示
   const relativeTime = $derived(() => formatRelativeTime(post.createdAt));
@@ -25,6 +47,28 @@
   const hasValidDisplayName = $derived(
     post.author.displayName && post.author.displayName.trim() !== ''
   );
+  
+
+  // アクションボタンハンドラー（将来のAT Protocol連携用）
+  function handleReply() {
+    console.log('Reply to post:', post.uri);
+    // TODO: 返信UI実装
+  }
+
+  function handleRepost() {
+    console.log('Repost:', post.uri);
+    // TODO: リポスト実装
+  }
+
+  function handleLike() {
+    console.log('Like post:', post.uri);
+    // TODO: いいね実装
+  }
+
+  function handleMore() {
+    console.log('More options for post:', post.uri);
+    // TODO: その他メニュー実装
+  }
 </script>
 
 <!-- ポストカード -->
@@ -77,7 +121,45 @@
   </header>
   
   <!-- 投稿内容 -->
-  <div class="text-themed text-sm leading-relaxed whitespace-pre-wrap break-words">
+  <div class="text-themed text-sm leading-relaxed whitespace-pre-wrap break-words mb-3">
     {post.text}
   </div>
+
+  <!-- アクションボタンエリア -->
+  <footer class="flex items-center justify-between">
+    <div class="flex items-center {getActionButtonGap(columnWidth)}">
+      <!-- 返信ボタン -->
+      <PostActionButton 
+        icon={ICONS.REPLY}
+        count={post.replyCount}
+        label="返信"
+        onclick={handleReply}
+      />
+      
+      <!-- リポストボタン -->
+      <PostActionButton 
+        icon={ICONS.REPEAT}
+        count={post.repostCount}
+        label="リポスト"
+        onclick={handleRepost}
+      />
+      
+      <!-- いいねボタン -->
+      <PostActionButton 
+        icon={ICONS.HEART_OUTLINE}
+        count={post.likeCount}
+        label="いいね"
+        onclick={handleLike}
+      />
+    </div>
+
+    <!-- その他メニューボタン -->
+    <PostActionButton 
+      icon={ICONS.MORE_HORIZ}
+      label="その他のオプション"
+      onclick={handleMore}
+      hideCount={true}
+      class="ml-auto"
+    />
+  </footer>
 </article>

--- a/moodeSky/src/lib/components/post/PostActionButton.svelte
+++ b/moodeSky/src/lib/components/post/PostActionButton.svelte
@@ -1,0 +1,134 @@
+<!--
+  PostActionButton.svelte
+  投稿用アクションボタンコンポーネント
+  リプライ・リポスト・いいね・その他メニュー用の統一ボタン
+-->
+<script lang="ts">
+  import Icon from '$lib/components/Icon.svelte';
+  import { formatActionCount, formatFullCount } from '$lib/utils/formatNumber.js';
+  import type { IconName } from '$lib/types/icon.js';
+
+  interface Props {
+    /** アイコン名 */
+    icon: IconName;
+    /** カウント数 */
+    count?: number | null;
+    /** ボタンのラベル（アクセシビリティ用） */
+    label: string;
+    /** アクティブ状態（いいね済み等） */
+    isActive?: boolean;
+    /** 無効状態 */
+    disabled?: boolean;
+    /** 数値表示を隠すかどうか */
+    hideCount?: boolean;
+    /** クリックハンドラー */
+    onclick?: () => void;
+    /** 追加CSSクラス */
+    class?: string;
+  }
+
+  const { 
+    icon, 
+    count = 0, 
+    label, 
+    isActive = false, 
+    disabled = false, 
+    hideCount = false,
+    onclick,
+    class: additionalClass = ''
+  }: Props = $props();
+
+  // フォーマットされた数値表示
+  const displayCount = $derived(() => formatActionCount(count));
+  
+  // ツールチップ用の詳細数値
+  const fullCount = $derived(() => formatFullCount(count));
+  
+  // ボタンのスタイルクラス
+  const buttonClass = $derived(() => {
+    const baseClass = 'group flex items-center gap-1.5 p-2 rounded-lg transition-all duration-200 hover:bg-muted/10 disabled:opacity-50 disabled:cursor-not-allowed';
+    const activeClass = isActive ? 'text-primary' : 'text-secondary hover:text-themed';
+    return `${baseClass} ${activeClass} ${additionalClass}`.trim();
+  });
+
+  // aria-labelとtitleの内容
+  const accessibilityText = $derived(() => {
+    if (hideCount) {
+      return label;
+    }
+    return `${label}: ${fullCount()}`;
+  });
+
+  // アイコンのcolor設定
+  const iconColor = $derived(() => {
+    if (disabled) return 'inactive';
+    if (isActive) return 'primary';
+    return 'secondary';
+  });
+
+  // ホバー時のアイコンスケール効果
+  const iconClass = $derived(() => {
+    return disabled ? '' : 'group-hover:scale-110 transition-transform duration-200';
+  });
+</script>
+
+<!-- アクションボタン -->
+<button
+  class={buttonClass()}
+  {disabled}
+  onclick={onclick}
+  aria-label={accessibilityText()}
+  title={accessibilityText()}
+>
+  <!-- アイコン -->
+  <Icon 
+    {icon} 
+    size="sm" 
+    color={iconColor()}
+    class={iconClass()}
+  />
+  
+  <!-- カウント表示（hideCountがfalseの場合のみ） -->
+  {#if !hideCount}
+    <span class="text-sm font-medium min-w-0 tabular-nums">
+      {displayCount()}
+    </span>
+  {/if}
+</button>
+
+<!--
+使用例:
+
+リプライボタン:
+<PostActionButton 
+  icon={ICONS.REPLY}
+  count={post.replyCount}
+  label="返信"
+  onclick={() => handleReply()}
+/>
+
+リポストボタン（アクティブ状態）:
+<PostActionButton 
+  icon={ICONS.REPEAT}
+  count={post.repostCount}
+  label="リポスト" 
+  isActive={true}
+  onclick={() => handleRepost()}
+/>
+
+いいねボタン:
+<PostActionButton 
+  icon={ICONS.FAVORITE}
+  count={post.likeCount}
+  label="いいね"
+  isActive={post.isLiked}
+  onclick={() => handleLike()}
+/>
+
+その他メニュー:
+<PostActionButton 
+  icon={ICONS.MORE_HORIZ}
+  label="その他のオプション"
+  onclick={() => showMenu()}
+/>
+-->

--- a/moodeSky/src/lib/deck/components/DeckColumn.svelte
+++ b/moodeSky/src/lib/deck/components/DeckColumn.svelte
@@ -532,7 +532,7 @@
       <!-- タイムライン表示 -->
       <div class="space-y-2 p-2">
         {#each posts as post (post.uri)}
-          <PostCard {post} />
+          <PostCard {post} columnWidth={column.settings.width} />
         {/each}
       </div>
     {:else if isInitialLoading}

--- a/moodeSky/src/lib/deck/components/DeckSettingsModal.svelte
+++ b/moodeSky/src/lib/deck/components/DeckSettingsModal.svelte
@@ -107,7 +107,7 @@ import { message } from '@tauri-apps/plugin-dialog';
     try {
       isSavingSize = true;
       
-      // TODO: deckStore.updateDeckSize(deckId, size);
+      await deckStore.updateColumnSettings(deckId, { width: size });
       console.log('🎛️ [DeckSettings] Deck size update:', { deckId, newSize: size });
       
       currentDeckSize = size;
@@ -167,11 +167,10 @@ import { message } from '@tauri-apps/plugin-dialog';
   // デッキサイズの初期化（deckStoreから取得）
   $effect(() => {
     if (isOpen && deckId && deckStore.columns.length > 0) {
-      // TODO: 実際のデッキサイズをdeckStoreから取得
-      // const column = deckStore.columns.find(c => c.accountId === deckId);
-      // if (column) {
-      //   currentDeckSize = column.settings.width;
-      // }
+      const column = deckStore.columns.find(c => c.id === deckId);
+      if (column && column.settings.width) {
+        currentDeckSize = column.settings.width;
+      }
       console.log('🎛️ [DeckSettings] Initializing deck size for:', deckId);
     }
   });

--- a/moodeSky/src/lib/types/icon.ts
+++ b/moodeSky/src/lib/types/icon.ts
@@ -88,6 +88,8 @@ export const ICONS = {
   // Bluesky/ソーシャルメディア機能
   FAVORITE: 'material-symbols:favorite',
   FAVORITE_BORDER: 'material-symbols:favorite-border',
+  // 代替ハートアイコン（フォールバック用）
+  HEART_OUTLINE: 'material-symbols:favorite-outline',
   REPEAT: 'material-symbols:repeat',
   CHAT_BUBBLE: 'material-symbols:chat-bubble-outline',
   REPLY: 'material-symbols:reply',

--- a/moodeSky/src/lib/utils/formatNumber.ts
+++ b/moodeSky/src/lib/utils/formatNumber.ts
@@ -1,0 +1,94 @@
+/**
+ * 数値フォーマットユーティリティ
+ * ソーシャルメディアでよく使用される K, M 表記のフォーマット
+ */
+
+/**
+ * 数値を省略形式でフォーマット
+ * 0-999: そのまま表示
+ * 1,000-999,999: K表記（例: 1.2K）
+ * 1,000,000+: M表記（例: 1.2M）
+ * 
+ * @param count 数値
+ * @returns フォーマットされた文字列
+ */
+export function formatCount(count: number | undefined | null): string {
+  // null/undefined チェック
+  if (count === null || count === undefined) {
+    return '0';
+  }
+
+  // 負の数は0として扱う
+  if (count < 0) {
+    return '0';
+  }
+
+  // 1000未満はそのまま表示
+  if (count < 1000) {
+    return count.toString();
+  }
+
+  // 1000以上999999以下はK表記
+  if (count < 1000000) {
+    const thousands = count / 1000;
+    // 小数点以下1桁、末尾0は省略
+    const formatted = thousands.toFixed(1);
+    return formatted.endsWith('.0') ? 
+      Math.floor(thousands).toString() + 'K' : 
+      formatted + 'K';
+  }
+
+  // 1000000以上はM表記
+  const millions = count / 1000000;
+  const formatted = millions.toFixed(1);
+  return formatted.endsWith('.0') ? 
+    Math.floor(millions).toString() + 'M' : 
+    formatted + 'M';
+}
+
+/**
+ * 数値をフルフォーマット（カンマ区切り）で表示
+ * ツールチップ等での詳細表示用
+ * 
+ * @param count 数値
+ * @returns カンマ区切りの文字列
+ */
+export function formatFullCount(count: number | undefined | null): string {
+  if (count === null || count === undefined) {
+    return '0';
+  }
+
+  if (count < 0) {
+    return '0';
+  }
+
+  return count.toLocaleString('ja-JP');
+}
+
+/**
+ * アクションボタン用の数値表示
+ * 0でも表示する仕様に対応
+ * 
+ * @param count 数値
+ * @returns フォーマットされた文字列（0も含む）
+ */
+export function formatActionCount(count: number | undefined | null): string {
+  // null/undefined の場合は0を表示
+  if (count === null || count === undefined) {
+    return '0';
+  }
+
+  // 負の数は0として扱う
+  if (count < 0) {
+    return '0';
+  }
+
+  return formatCount(count);
+}
+
+/**
+ * テスト用の型チェック関数
+ */
+export function isValidCount(count: unknown): count is number {
+  return typeof count === 'number' && !isNaN(count) && isFinite(count);
+}


### PR DESCRIPTION
## Summary
- ポストカード内にアクションボタン（返信・リポスト・いいね・その他）を追加
- デッキサイズに応じた黄金比・フィボナッチ数列を意識した美しいギャップ調整機能を実装
- デッキサイズ変更機能の修正（モーダルからの変更が実際に反映されるように改善）

## 主な変更内容

### 🎯 ポストアクションボタンの実装
- **PostActionButton.svelte**: 統一されたアクションボタンコンポーネント
- **数値フォーマット**: K/M表記対応（1000→1K、1000000→1M）
- **アクセシビリティ**: WCAG準拠のaria-label、title属性
- **アイコン**: Material Symbols統合、いいねアイコン表示問題を修正

### ✨ 黄金比ギャップシステム
デッキサイズに応じた美しいアクションボタン間隔を実現：

| デッキサイズ | 幅 | ギャップ | 比率 |
|------------|----|---------|----- |
| xxs | 280px | 8px | 2.9% |
| xs | 320px | 24px | 7.5% |
| small | 380px | 48px | 12.6% |
| medium | 450px | 64px | 14.2% |
| large | 520px | 80px | 15.4% |
| xl | 600px | 112px | 18.7% |
| xxl | 720px | 160px | 22.2% |

### 🔧 デッキサイズ変更機能の修正
- **DeckSettingsModal.svelte**: サイズ保存処理とUI初期化を実装
- **実際のサイズ反映**: モーダルからの変更が即座にデッキ幅に反映
- **現在サイズ表示**: モーダル開時に正しい現在サイズを表示

### 📁 コンポーネント整理
- **post/** フォルダ: ポスト関連コンポーネントを整理
- **formatNumber.ts**: 数値フォーマット専用ユーティリティ

## Test plan
- [x] アクションボタンが正しく表示される
- [x] デッキサイズ変更時にギャップが適切に調整される
- [x] 数値フォーマット（K/M表記）が正常に動作する
- [x] いいねアイコンが表示される
- [x] moreボタンに数値が表示されない
- [x] デッキサイズ変更がリアルタイムで反映される
- [x] TypeScript型チェック通過

🤖 Generated with [Claude Code](https://claude.ai/code)