### PR TITLE
feat: 埋め込みコンテンツに統一された枠線と角丸を追加

### DIFF
--- a/moodeSky/.gitignore
+++ b/moodeSky/.gitignore
@@ -8,3 +8,25 @@ node_modules
 !.env.example
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Test files
+TEST_RESULTS.md
+test-*.mjs
+test-*.js
+test-*.ts
+*-test.js
+*-test.mjs
+
+# Test routes and utilities  
+src/routes/test-*/
+src/**/test-*
+src/**/*TestUtils.ts
+src/**/*-test-utils.ts
+
+# Development logs
+dev.log
+*.log
+
+# Temporary files
+*.tmp
+*.temp

--- a/moodeSky/docs/EMBEDDING_DATA_FLOW.md
+++ b/moodeSky/docs/EMBEDDING_DATA_FLOW.md
@@ -1,0 +1,328 @@
+# Post → Embedding データフロー詳細ドキュメント
+
+## 概要
+
+このドキュメントは、Postデータから埋め込みコンテンツ（embeddings）が表示されるまでの完全なデータフローを説明します。AT Protocolの埋め込みシステムと統合されたコンポーネント間の連携を理解するための参考資料です。
+
+## データフロー全体図
+
+```
+1. BlueskyAPI (AT Protocol)
+   ↓
+2. TimelineService.getTimeline()
+   ↓
+3. DeckColumn.svelte (API→SimplePostマッピング + 重複排除)
+   ↓
+4. PostCard.svelte (埋め込み検出 + EmbedRenderer呼び出し)
+   ↓
+5. EmbedRenderer.svelte (型判定 + 適切な埋め込みコンポーネント選択)
+   ↓
+6. 個別埋め込みコンポーネント (ImageEmbed, VideoEmbed, ExternalLinkEmbed, RecordEmbed, RecordWithMediaEmbed)
+```
+
+## 詳細データフロー
+
+### 1. API レスポンス (AT Protocol)
+
+**場所**: Bluesky API  
+**データ形式**: AT Protocol Feed Response
+
+```json
+{
+  "feed": [
+    {
+      "post": {
+        "uri": "at://did:plc:xxx/app.bsky.feed.post/xxx",
+        "cid": "xxx",
+        "author": { "did": "xxx", "handle": "user.bsky.social", ... },
+        "record": { "text": "投稿テキスト", ... },
+        "embed": {
+          "$type": "app.bsky.embed.images#view",
+          "images": [...]
+        },
+        "embeds": [...], // 複数埋め込みの場合
+        "replyCount": 0,
+        "repostCount": 5,
+        "likeCount": 10
+      }
+    }
+  ]
+}
+```
+
+### 2. TimelineService データ取得
+
+**ファイル**: `src/lib/services/timelineService.ts`  
+**関数**: `getTimeline(account: Account, agent: Agent)`
+
+```typescript
+const response = await agent.agent.getTimeline({ limit: 50 });
+return response.data.feed; // 生のAT Protocolデータ
+```
+
+**特徴**:
+- Agent注入による認証済みリクエスト
+- 最大50件の投稿を取得
+- エラーハンドリング（認証期限切れ、ネットワークエラー等）
+
+### 3. SimplePost変換 + 重複排除 (DeckColumn.svelte)
+
+**ファイル**: `src/lib/deck/components/DeckColumn.svelte`  
+**処理**: API応答を`SimplePost`形式に変換 + 重複URI排除
+
+```typescript
+// 1. AT Protocol → SimplePost マッピング
+const simplePosts: SimplePost[] = timelineData.map((item: any) => {
+  const post = item.post || item;
+  return {
+    uri: post.uri,
+    cid: post.cid,
+    author: { ... },
+    text: post.record?.text || '',
+    embed: post.embed,        // 単一埋め込み
+    embeds: post.embeds,      // 複数埋め込み
+    replyCount: post.replyCount,
+    // ...その他のフィールド
+  };
+});
+
+// 2. 重複URI排除 (each_key_duplicate エラー対策)
+const deduplicationMap = new Map<string, SimplePost>();
+for (const post of simplePosts) {
+  if (!deduplicationMap.has(post.uri)) {
+    deduplicationMap.set(post.uri, post);
+  }
+}
+const deduplicatedPosts = Array.from(deduplicationMap.values());
+```
+
+**重要な変更点**:
+- `embed`と`embeds`フィールドが正しくマッピングされている
+- Map-based重複排除でSvelteの`each_key_duplicate`エラーを解決
+- 埋め込み統計ログを出力
+
+### 4. PostCard埋め込み処理
+
+**ファイル**: `src/lib/components/PostCard.svelte`  
+**処理**: 埋め込みデータの統合 + EmbedRenderer呼び出し
+
+```typescript
+// 埋め込みコンテンツの存在チェック
+const hasEmbeds = $derived(() => {
+  return !!(post.embed || (post.embeds && post.embeds.length > 0));
+});
+
+// embedまたはembedsの統一化
+const embedsData = $derived(() => {
+  if (post.embeds && post.embeds.length > 0) {
+    return post.embeds; // 複数埋め込み優先
+  } else if (post.embed) {
+    return post.embed;  // 単一埋め込み
+  }
+  return null;
+});
+```
+
+**表示位置**:
+```svelte
+<!-- 投稿内容 -->
+<div class="text-themed text-sm leading-relaxed whitespace-pre-wrap break-words mb-3">
+  {post.text}
+</div>
+
+<!-- 埋め込みコンテンツエリア（正しい位置） -->
+{#if hasEmbeds()}
+  <div class="mb-3">
+    <EmbedRenderer embeds={embedsData()} ... />
+  </div>
+{/if}
+
+<!-- アクションボタンエリア -->
+<footer class="flex items-center justify-between">
+  <!-- 返信、リポスト、いいねボタン -->
+</footer>
+```
+
+### 5. EmbedRenderer型判定・ルーティング
+
+**ファイル**: `src/lib/components/embeddings/EmbedRenderer.svelte`  
+**処理**: 埋め込みタイプの自動判定と適切なコンポーネント選択
+
+```typescript
+// 埋め込みデータの正規化（配列統一）
+const normalizedEmbeds = $derived(() => {
+  if (!embeds) return [];
+  return Array.isArray(embeds) ? embeds.slice(0, maxEmbeds) : [embeds];
+});
+
+// 型判定とコンポーネント選択
+const renderEmbed = (embed: Embed | EmbedView, index: number) => {
+  const embedType = getEmbedType(embed); // 'images', 'video', 'external', 'record', 'recordWithMedia'
+  return { type: embedType, embed, error: null };
+};
+```
+
+**コンポーネントマッピング**:
+```svelte
+{#if type === 'images'}
+  <ImageEmbed embed={embed as any} ... />
+{:else if type === 'video'}
+  <VideoEmbed embed={embed as any} ... />
+{:else if type === 'external'}
+  <ExternalLinkEmbed embed={embed as any} ... />
+{:else if type === 'record'}
+  <RecordEmbed embed={embed as any} ... />
+{:else if type === 'recordWithMedia'}
+  <RecordWithMediaEmbed embed={embed as any} ... />
+{/if}
+```
+
+### 6. 個別埋め込みコンポーネント
+
+#### ImageEmbed (画像埋め込み)
+- **対応タイプ**: `app.bsky.embed.images#view`
+- **機能**: 画像ギャラリー、アスペクト比対応、レイジーローディング、クリック拡大
+
+#### VideoEmbed (動画埋め込み)
+- **対応タイプ**: `app.bsky.embed.video#view`
+- **機能**: 動画再生、コントロール、プログレスバー、フルスクリーン対応
+
+#### ExternalLinkEmbed (外部リンク埋め込み)
+- **対応タイプ**: `app.bsky.embed.external#view`
+- **機能**: リンクプレビュー、サムネイル、メタデータ表示
+
+#### RecordEmbed (記録埋め込み = 引用投稿)
+- **対応タイプ**: `app.bsky.embed.record#view`
+- **機能**: 引用投稿表示、ネスト深度制限、クリックナビゲーション
+
+#### RecordWithMediaEmbed (記録+メディア複合埋め込み)
+- **対応タイプ**: `app.bsky.embed.recordWithMedia#view`
+- **機能**: 引用投稿とメディアの組み合わせ表示、レイアウト調整
+
+## 型定義とインターフェース
+
+### SimplePost型
+```typescript
+export interface SimplePost {
+  uri: string;           // AT Protocol URI (一意キー)
+  cid: string;           // Content ID
+  author: PostAuthor;    // 作者情報
+  text: string;          // 投稿テキスト
+  embed?: Embed | EmbedView;        // 単一埋め込み
+  embeds?: (Embed | EmbedView)[];   // 複数埋め込み
+  replyCount?: number;
+  repostCount?: number;
+  likeCount?: number;
+  createdAt: string;
+  indexedAt: string;
+}
+```
+
+### 埋め込みタイプ階層
+```typescript
+// ベースタイプ
+type Embed = ImageEmbed | VideoEmbed | ExternalEmbed | RecordEmbed | RecordWithMediaEmbed;
+type EmbedView = ImageEmbedView | VideoEmbedView | ExternalEmbedView | RecordEmbedView | RecordWithMediaEmbedView;
+
+// 具体的な埋め込みタイプ
+interface ImageEmbed { $type: 'app.bsky.embed.images'; images: ImageItem[]; }
+interface VideoEmbed { $type: 'app.bsky.embed.video'; video: VideoItem; }
+interface ExternalEmbed { $type: 'app.bsky.embed.external'; external: ExternalItem; }
+interface RecordEmbed { $type: 'app.bsky.embed.record'; record: RecordRef; }
+interface RecordWithMediaEmbed { $type: 'app.bsky.embed.recordWithMedia'; record: RecordRef; media: Embed; }
+```
+
+## エラーハンドリング
+
+### 重複URI処理
+- **問題**: AT Protocolフィードに同じpost.uriが複数含まれる
+- **解決**: Map-based重複排除でSvelteの`each_key_duplicate`エラーを解決
+- **実装**: DeckColumn.svelte lines 355-381
+
+### 型安全性
+- **問題**: TypeScript型エラー（Generic embed型 vs 具体的コンポーネント型）
+- **解決**: `as any`キャストでEmbedRenderer内の型強制
+- **実装**: EmbedRenderer.svelte lines 221-256
+
+### 埋め込みエラー
+- **問題**: 不正な埋め込みデータ、読み込み失敗
+- **解決**: バリデーション、エラー境界、フォールバック表示
+- **実装**: 各埋め込みコンポーネント内のエラーハンドリング
+
+## デバッグとモニタリング
+
+### ログ出力
+```typescript
+console.log('📋 [DeckColumn] Timeline deduplication stats:', {
+  originalCount: simplePosts.length,
+  deduplicatedCount: deduplicatedPosts.length,
+  duplicatesRemoved: simplePosts.length - deduplicatedPosts.length,
+  embedStats: { withEmbed: 0, withEmbeds: 0, total: 0 }
+});
+```
+
+### デバッグモード
+```svelte
+<EmbedRenderer embeds={post.embeds} debug={true} />
+```
+
+デバッグモードでは以下の情報を表示:
+- 埋め込み総数・有効数
+- 埋め込みタイプ別統計
+- エラー詳細メッセージ
+
+## パフォーマンス最適化
+
+### レイジーローディング
+- 画像: `loading="lazy"`対応
+- 埋め込み: 表示制限 (`maxEmbeds=3`)
+
+### メモリ効率
+- 重複排除によるメモリ使用量削減
+- 大量埋め込みデータの制限表示
+
+### レンダリング最適化
+- Svelte 5 runesによるリアクティブ計算
+- 条件付きレンダリングによる不要な計算回避
+
+## トラブルシューティング
+
+### よくある問題
+
+1. **タイムラインが表示されない**
+   - 原因: `each_key_duplicate`エラー
+   - 確認: ブラウザコンソールで重複URI検出
+   - 解決: 重複排除ロジックが正常動作することを確認
+
+2. **埋め込みが表示されない**
+   - 原因: `embed`/`embeds`フィールドマッピング漏れ
+   - 確認: DeckColumn.svelte lines 346-347
+   - 解決: SimplePost変換時にembed要素を含める
+
+3. **TypeScriptエラー**
+   - 原因: 埋め込み型の複雑な継承関係
+   - 確認: svelte-check実行
+   - 解決: 適切な型キャスト (`as any`)
+
+### デバッグ手順
+
+1. **コンソールログ確認**
+   ```
+   📋 [DeckColumn] Timeline deduplication stats
+   ```
+
+2. **埋め込み統計確認**
+   ```typescript
+   embedStats: { withEmbed: 2, withEmbeds: 1, total: 31 }
+   ```
+
+3. **EmbedRendererデバッグモード**
+   ```svelte
+   <EmbedRenderer debug={true} />
+   ```
+
+## まとめ
+
+このデータフローにより、AT Protocolの複雑な埋め込みシステムが統一されたインターフェースでレンダリングされます。重複排除ロジックによりSvelteの制約を回避し、型安全性を保ちながら拡張可能な埋め込みシステムを実現しています。
+
+埋め込み表示は投稿テキストとアクションボタンの間の正しい位置に配置され、ユーザーエクスペリエンスとアクセシビリティを考慮した実装となっています。

--- a/moodeSky/src/lib/components/PostCard.svelte
+++ b/moodeSky/src/lib/components/PostCard.svelte
@@ -51,57 +51,17 @@
 
   // 埋め込みコンテンツの存在チェック
   const hasEmbeds = $derived(() => {
-    const result = !!(post.embed || (post.embeds && post.embeds.length > 0));
-    
-    // デバッグログ: 埋め込み検出状況（$state.snapshot使用）
-    if (post.embed || post.embeds) {
-      console.log('🎯 [PostCard] Embed detection for post:', $state.snapshot({
-        postUri: post.uri,
-        hasEmbed: !!post.embed,
-        embedType: post.embed?.$type,
-        hasEmbeds: !!(post.embeds && post.embeds.length > 0),
-        embedsCount: post.embeds?.length || 0,
-        embedsTypes: post.embeds?.map(e => e.$type) || [],
-        hasEmbeds_result: result,
-        rawEmbed: post.embed,
-        rawEmbeds: post.embeds
-      }));
-    }
-    
-    return result;
+    return !!(post.embed || (post.embeds && post.embeds.length > 0));
   });
 
   // 埋め込みデータの統一化（embed または embeds）
   const embedsData = $derived(() => {
-    let result = null;
-    
     if (post.embeds && post.embeds.length > 0) {
-      result = $state.snapshot(post.embeds);  // スナップショット化
-      console.log('🎯 [PostCard] Using post.embeds (snapshot):', {
-        postUri: post.uri,
-        embedsCount: post.embeds.length,
-        resultType: Array.isArray(result) ? `Array(${result.length})` : typeof result,
-        resultStructure: result,
-        hasTypes: result ? result.map(e => e?.$type) : 'none'
-      });
+      return post.embeds;
     } else if (post.embed) {
-      result = $state.snapshot(post.embed);  // スナップショット化
-      console.log('🎯 [PostCard] Using post.embed (snapshot):', {
-        postUri: post.uri,
-        embedType: post.embed.$type,
-        resultType: typeof result,
-        resultStructure: result,
-        hasType: result?.$type || 'missing'
-      });
-    } else {
-      console.log('🎯 [PostCard] No embed data found:', {
-        postUri: post.uri,
-        hasEmbed: !!post.embed,
-        hasEmbeds: !!(post.embeds && post.embeds.length > 0)
-      });
+      return post.embed;
     }
-    
-    return result;
+    return null;
   });
 
   // アクションボタンハンドラー（将来のAT Protocol連携用）
@@ -221,11 +181,6 @@
   <!-- 埋め込みコンテンツエリア -->
   {#if hasEmbeds()}
     <div class="mb-3">
-      {console.log('🎯 [PostCard] Rendering EmbedRenderer with data:', {
-        postUri: post.uri,
-        embedsData: embedsData(),
-        hasEmbeds: hasEmbeds()
-      })}
       <EmbedRenderer 
         embeds={embedsData()}
         options={{
@@ -252,12 +207,6 @@
         debug={true}
       />
     </div>
-  {:else}
-    {console.log('🎯 [PostCard] No embeds to render for post:', {
-      postUri: post.uri,
-      hasEmbeds: hasEmbeds(),
-      embedsData: embedsData()
-    })}
   {/if}
 
   <!-- アクションボタンエリア -->

--- a/moodeSky/src/lib/components/embeddings/EmbedRenderer.svelte
+++ b/moodeSky/src/lib/components/embeddings/EmbedRenderer.svelte
@@ -1,0 +1,412 @@
+<!--
+  EmbedRenderer.svelte
+  統合埋め込みレンダラーコンポーネント
+  すべての埋め込みタイプを自動判定して適切なコンポーネントをレンダリング
+  
+  対応する埋め込みタイプ:
+  - app.bsky.embed.images / app.bsky.embed.images#view
+  - app.bsky.embed.video / app.bsky.embed.video#view  
+  - app.bsky.embed.external / app.bsky.embed.external#view
+  - app.bsky.embed.record / app.bsky.embed.record#view
+  - app.bsky.embed.recordWithMedia / app.bsky.embed.recordWithMedia#view
+-->
+<script lang="ts">
+  import ImageEmbed from './ImageEmbed.svelte';
+  import VideoEmbed from './VideoEmbed.svelte';
+  import ExternalLinkEmbed from './ExternalLinkEmbed.svelte';
+  import RecordEmbed from './RecordEmbed.svelte';
+  import RecordWithMediaEmbed from './RecordWithMediaEmbed.svelte';
+  import Icon from '$lib/components/Icon.svelte';
+  import { ICONS } from '$lib/types/icon.js';
+  import type { 
+    Embed, 
+    EmbedView, 
+    EmbedDisplayOptions,
+    EmbedType
+  } from './types.js';
+  import { 
+    DEFAULT_EMBED_DISPLAY_OPTIONS,
+    isImageEmbed,
+    isImageEmbedView,
+    isVideoEmbed,
+    isVideoEmbedView,
+    isExternalEmbed,
+    isExternalEmbedView,
+    isRecordEmbed,
+    isRecordEmbedView,
+    isRecordWithMediaEmbed,
+    isRecordWithMediaEmbedView,
+    getEmbedType,
+    validateEmbed
+  } from './types.js';
+
+  interface Props {
+    /** 埋め込みデータ（単一または配列） */
+    embeds?: (Embed | EmbedView)[] | Embed | EmbedView | null;
+    /** 表示オプション */
+    options?: Partial<EmbedDisplayOptions>;
+    /** 追加CSSクラス */
+    class?: string;
+    /** 引用投稿クリック時の処理 */
+    onPostClick?: (uri: string, cid: string) => void;
+    /** 作者クリック時の処理 */
+    onAuthorClick?: (did: string, handle: string) => void;
+    /** 画像クリック時の処理 */
+    onImageClick?: (imageIndex: number, imageUrl: string) => void;
+    /** 動画クリック時の処理 */
+    onVideoClick?: (videoUrl: string) => void;
+    /** 外部リンククリック時の処理 */
+    onLinkClick?: (url: string, event: MouseEvent) => void;
+    /** メディアクリック時の汎用処理 */
+    onMediaClick?: (mediaUrl: string, mediaType: string) => void;
+    /** エラー時の処理 */
+    onError?: (error: Error, embed: unknown) => void;
+    /** 最大表示数（配列の場合） */
+    maxEmbeds?: number;
+    /** デバッグモード */
+    debug?: boolean;
+  }
+
+  const { 
+    embeds, 
+    options = {}, 
+    class: additionalClass = '',
+    onPostClick,
+    onAuthorClick,
+    onImageClick,
+    onVideoClick,
+    onLinkClick,
+    onMediaClick,
+    onError,
+    maxEmbeds = 10,
+    debug = false
+  }: Props = $props();
+
+  // 表示設定のマージ
+  const displayOptions = $derived({ ...DEFAULT_EMBED_DISPLAY_OPTIONS, ...options });
+
+  // 埋め込みデータの正規化（配列に統一）
+  const normalizedEmbeds = $derived(() => {
+    if (!embeds) return [];
+    
+    if (Array.isArray(embeds)) {
+      return embeds.slice(0, maxEmbeds);
+    }
+    
+    return [embeds];
+  });
+
+  // 有効な埋め込みデータのフィルタリング
+  const validEmbeds = $derived(() => {
+    const normalized = normalizedEmbeds();
+    
+    if (debug) {
+      console.log('🔍 [EmbedRenderer] Starting validation:', {
+        embeds: embeds,
+        embedsType: Array.isArray(embeds) ? `Array(${embeds.length})` : typeof embeds,
+        normalized: normalized,
+        normalizedCount: normalized.length
+      });
+    }
+    
+    return normalized.filter((embed, index) => {
+      try {
+        if (!embed || typeof embed !== 'object') {
+          if (debug) console.warn(`🚫 [EmbedRenderer] Embed ${index} is not a valid object:`, { embed, type: typeof embed });
+          return false;
+        }
+        
+        // より緩和された基本的な検証
+        if (!embed.$type || typeof embed.$type !== 'string') {
+          if (debug) console.warn(`🚫 [EmbedRenderer] Embed ${index} missing $type:`, { embed, hasType: !!embed.$type, type: embed.$type });
+          return false;
+        }
+        
+        // 基本的なAT Protocol埋め込みタイプかどうかチェック
+        const isValidType = embed.$type.startsWith('app.bsky.embed.');
+        if (!isValidType) {
+          if (debug) console.warn(`🚫 [EmbedRenderer] Embed ${index} invalid $type:`, { embed, type: embed.$type });
+          return false;
+        }
+        
+        if (debug) {
+          console.log(`✅ [EmbedRenderer] Embed ${index} passed validation:`, { 
+            type: embed.$type, 
+            hasValidStructure: !!embed,
+            embedKeys: Object.keys(embed)
+          });
+        }
+        
+        return true;
+      } catch (error) {
+        if (debug) console.error(`❌ [EmbedRenderer] Error validating embed ${index}:`, { error, embed });
+        if (onError) {
+          onError(error as Error, embed);
+        }
+        return false;
+      }
+    });
+  });
+
+  // エラーハンドリング付きのコンポーネントレンダリング
+  const renderEmbed = (embed: Embed | EmbedView, index: number) => {
+    try {
+      const embedType = getEmbedType(embed);
+      
+      if (debug) {
+        console.log(`Rendering embed ${index} of type: ${embedType}`, embed);
+      }
+      
+      return { type: embedType, embed, error: null };
+    } catch (error) {
+      if (debug) {
+        console.error(`Error processing embed ${index}:`, error, embed);
+      }
+      if (onError) {
+        onError(error as Error, embed);
+      }
+      return { type: null, embed, error: error as Error };
+    }
+  };
+
+  // 各埋め込みのレンダリング情報
+  const renderableEmbeds = $derived(() => {
+    return validEmbeds().map(renderEmbed);
+  });
+
+  // 統計情報（デバッグ用）
+  const embedStats = $derived(() => {
+    if (!debug) return null;
+    
+    const stats = {
+      total: normalizedEmbeds().length,
+      valid: validEmbeds().length,
+      types: {} as Record<string, number>
+    };
+    
+    renderableEmbeds().forEach(({ type }) => {
+      if (type) {
+        stats.types[type] = (stats.types[type] || 0) + 1;
+      }
+    });
+    
+    return stats;
+  });
+
+  // 複合メディアクリックハンドラー
+  const handleMediaClick = (mediaUrl: string, mediaType: string) => {
+    if (onMediaClick) {
+      onMediaClick(mediaUrl, mediaType);
+    } else {
+      // デフォルトの処理
+      if (mediaType === 'image' && onImageClick) {
+        onImageClick(0, mediaUrl);
+      } else if (mediaType === 'video' && onVideoClick) {
+        onVideoClick(mediaUrl);
+      }
+    }
+  };
+
+  // 画像クリックハンドラー（ImageEmbed用）
+  const handleImageEmbedClick = (imageIndex: number, imageUrl: string) => {
+    if (onImageClick) {
+      onImageClick(imageIndex, imageUrl);
+    } else if (onMediaClick) {
+      onMediaClick(imageUrl, 'image');
+    }
+  };
+</script>
+
+<!-- 埋め込みレンダラーコンテナ -->
+{#if validEmbeds().length > 0}
+  <div class="w-full {additionalClass}">
+    <!-- デバッグ情報 -->
+    {#if debug && embedStats()}
+      <div class="mb-2 p-2 bg-muted/10 rounded text-xs text-secondary">
+        <strong>Embed Debug:</strong>
+        Total: {embedStats()?.total}, Valid: {embedStats()?.valid}
+        {#if embedStats()?.types && Object.keys(embedStats()?.types || {}).length > 0}
+          | Types: {Object.entries(embedStats()?.types || {}).map(([type, count]) => `${type}(${count})`).join(', ')}
+        {/if}
+      </div>
+    {/if}
+
+    <!-- 埋め込みコンテンツ -->
+    <div class="space-y-3">
+      {#each renderableEmbeds() as { type, embed, error }, index}
+        {#if error}
+          <!-- エラー表示 -->
+          <div class="p-3 border border-error/20 bg-error/5 rounded-lg text-center">
+            <Icon icon={ICONS.ERROR} size="md" color="error" class="mx-auto mb-1" />
+            <p class="text-error text-sm">埋め込みコンテンツを読み込めませんでした</p>
+            {#if debug}
+              <p class="text-error text-xs mt-1 font-mono">{error.message}</p>
+            {/if}
+          </div>
+        {:else if type === 'images'}
+          <!-- 画像埋め込み -->
+          <ImageEmbed 
+            embed={embed as any}
+            options={options}
+            onClick={handleImageEmbedClick}
+          />
+        {:else if type === 'video'}
+          <!-- 動画埋め込み -->
+          <VideoEmbed 
+            embed={embed as any}
+            options={options}
+          />
+        {:else if type === 'external'}
+          <!-- 外部リンク埋め込み -->
+          <ExternalLinkEmbed 
+            embed={embed as any}
+            options={options}
+            onLinkClick={onLinkClick}
+          />
+        {:else if type === 'record'}
+          <!-- 記録埋め込み -->
+          <RecordEmbed 
+            embed={embed as any}
+            options={options}
+            onPostClick={onPostClick}
+            onAuthorClick={onAuthorClick}
+          />
+        {:else if type === 'recordWithMedia'}
+          <!-- 記録+メディア埋め込み -->
+          <RecordWithMediaEmbed 
+            embed={embed as any}
+            options={options}
+            onPostClick={onPostClick}
+            onAuthorClick={onAuthorClick}
+            onMediaClick={handleMediaClick}
+            onLinkClick={onLinkClick}
+          />
+        {:else}
+          <!-- 未知の埋め込みタイプ -->
+          <div class="p-3 border border-subtle bg-muted/5 rounded-lg text-center">
+            <Icon icon={ICONS.HELP_CIRCLE} size="md" color="secondary" class="mx-auto mb-1" />
+            <p class="text-secondary text-sm">未対応の埋め込みタイプ</p>
+            {#if debug}
+              <p class="text-secondary text-xs mt-1 font-mono">
+                Type: {type || 'unknown'} | $type: {embed?.$type || 'missing'}
+              </p>
+            {/if}
+          </div>
+        {/if}
+      {/each}
+    </div>
+
+    <!-- 表示制限通知 -->
+    {#if normalizedEmbeds().length > maxEmbeds}
+      <div class="mt-3 p-2 bg-muted/10 rounded text-center">
+        <p class="text-secondary text-sm">
+          {normalizedEmbeds().length - maxEmbeds} 個の追加埋め込みコンテンツがあります
+        </p>
+      </div>
+    {/if}
+  </div>
+{:else if embeds !== null && embeds !== undefined}
+  <!-- 埋め込みデータはあるが無効な場合 -->
+  {#if debug}
+    <div class="p-3 border border-warning/20 bg-warning/5 rounded-lg text-center">
+      <Icon icon={ICONS.WARNING} size="md" color="warning" class="mx-auto mb-1" />
+      <p class="text-warning text-sm">有効な埋め込みコンテンツが見つかりませんでした</p>
+      <div class="text-warning text-xs mt-2 space-y-1">
+        <p class="font-mono">
+          Input: {Array.isArray(embeds) ? `Array(${embeds.length})` : typeof embeds}
+        </p>
+        <p class="font-mono">
+          Normalized: {normalizedEmbeds().length} items
+        </p>
+        <p class="font-mono">
+          Valid: {validEmbeds().length} items
+        </p>
+        {#if normalizedEmbeds().length > 0 && normalizedEmbeds()[0]}
+          <p class="font-mono">
+            Sample $type: {normalizedEmbeds()[0].$type || 'missing'}
+          </p>
+          <p class="font-mono">
+            Sample keys: {Object.keys(normalizedEmbeds()[0] || {}).join(', ')}
+          </p>
+        {/if}
+      </div>
+    </div>
+  {/if}
+{/if}
+
+<!--
+使用例:
+
+基本的な使用（単一埋め込み）:
+<EmbedRenderer embeds={post.embed} />
+
+複数埋め込み:
+<EmbedRenderer embeds={post.embeds} />
+
+すべてのハンドラー付き:
+<EmbedRenderer 
+  embeds={post.embeds}
+  onPostClick={(uri, cid) => navigateToPost(uri)}
+  onAuthorClick={(did, handle) => navigateToProfile(handle)}
+  onImageClick={(index, url) => openImageViewer(url)}
+  onVideoClick={(url) => openVideoPlayer(url)}
+  onLinkClick={(url, event) => handleExternalLink(url)}
+  onMediaClick={(url, type) => openMediaViewer(url, type)}
+  onError={(error, embed) => logError(error, embed)}
+/>
+
+カスタムオプション:
+<EmbedRenderer 
+  embeds={post.embeds}
+  options={{
+    maxWidth: 600,
+    rounded: true,
+    interactive: true,
+    clickable: true
+  }}
+  maxEmbeds={5}
+/>
+
+デバッグモード:
+<EmbedRenderer 
+  embeds={post.embeds}
+  debug={true}
+/>
+-->
+
+<style>
+  /* 埋め込み間のスペース */
+  .space-y-3 > * + * {
+    margin-top: 0.75rem;
+  }
+  
+  /* デバッグ情報のスタイル */
+  .font-mono {
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace;
+  }
+  
+  /* エラー状態の視覚的強調 */
+  .border-error\/20 {
+    border-color: rgb(239 68 68 / 0.2);
+  }
+  
+  .bg-error\/5 {
+    background-color: rgb(239 68 68 / 0.05);
+  }
+  
+  .text-error {
+    color: rgb(239 68 68);
+  }
+  
+  .border-warning\/20 {
+    border-color: rgb(245 158 11 / 0.2);
+  }
+  
+  .bg-warning\/5 {
+    background-color: rgb(245 158 11 / 0.05);
+  }
+  
+  .text-warning {
+    color: rgb(245 158 11);
+  }
+</style>

--- a/moodeSky/src/lib/components/embeddings/ExternalLinkEmbed.svelte
+++ b/moodeSky/src/lib/components/embeddings/ExternalLinkEmbed.svelte
@@ -1,0 +1,329 @@
+<!--
+  ExternalLinkEmbed.svelte
+  外部リンク埋め込みコンポーネント
+  app.bsky.embed.external および app.bsky.embed.external#view 対応
+  リンクプレビューカード、メタデータ表示、サムネイル対応
+-->
+<script lang="ts">
+  import Icon from '$lib/components/Icon.svelte';
+  import { ICONS } from '$lib/types/icon.js';
+  import type { ExternalEmbed, ExternalEmbedView, EmbedDisplayOptions } from './types.js';
+  import { DEFAULT_EMBED_DISPLAY_OPTIONS } from './types.js';
+
+  interface Props {
+    /** 外部リンク埋め込みデータ */
+    embed: ExternalEmbed | ExternalEmbedView;
+    /** 表示オプション */
+    options?: Partial<EmbedDisplayOptions>;
+    /** 追加CSSクラス */
+    class?: string;
+    /** リンククリック時の処理（デフォルト: 新しいタブで開く） */
+    onLinkClick?: (url: string, event: MouseEvent) => void;
+    /** 画像クリック時の処理（デフォルト: リンククリックと同じ） */
+    onImageClick?: (imageUrl: string, linkUrl: string, event: MouseEvent) => void;
+  }
+
+  const { 
+    embed, 
+    options = {}, 
+    class: additionalClass = '',
+    onLinkClick,
+    onImageClick
+  }: Props = $props();
+
+  // 内部状態
+  let imageLoaded = $state(false);
+  let imageError = $state(false);
+
+  // 表示設定のマージ
+  const displayOptions = $derived({ ...DEFAULT_EMBED_DISPLAY_OPTIONS, ...options });
+
+  // 外部リンクデータの正規化（embed vs embedView の違いを吸収）
+  const linkData = $derived(() => {
+    const result = {
+      uri: embed.external.uri,
+      title: embed.external.title || 'Untitled',
+      description: embed.external.description || '',
+      thumb: 'thumb' in embed.external && embed.external.thumb 
+        ? (typeof embed.external.thumb === 'string' ? embed.external.thumb : '#')
+        : undefined
+    };
+    
+    console.log('🔗 [ExternalLinkEmbed] Link data parsed:', {
+      hasThumb: !!result.thumb,
+      thumbUrl: result.thumb,
+      title: result.title,
+      description: result.description?.slice(0, 50) + '...'
+    });
+    
+    return result;
+  });
+
+  // ドメイン名を抽出
+  const domain = $derived(() => {
+    try {
+      const url = new URL(linkData().uri);
+      return url.hostname.replace(/^www\./, '');
+    } catch {
+      return linkData().uri;
+    }
+  });
+
+  // リンククリックハンドラー
+  const handleLinkClick = (event: MouseEvent) => {
+    if (onLinkClick) {
+      event.preventDefault();
+      onLinkClick(linkData().uri, event);
+    } else {
+      // デフォルト: 新しいタブで開く
+      window.open(linkData().uri, '_blank', 'noopener,noreferrer');
+      event.preventDefault();
+    }
+  };
+
+  // 画像クリックハンドラー
+  const handleImageClick = (event: MouseEvent) => {
+    const thumb = linkData().thumb;
+    if (onImageClick && thumb) {
+      event.preventDefault();
+      event.stopPropagation();
+      onImageClick(thumb, linkData().uri, event);
+    } else {
+      // デフォルト: リンククリックと同じ動作
+      handleLinkClick(event);
+    }
+  };
+
+  // 画像読み込み完了ハンドラー
+  const handleImageLoad = (event: Event) => {
+    console.log('🖼️ [ExternalLinkEmbed] Image loaded successfully:', {
+      url: linkData().thumb,
+      imageLoaded: imageLoaded,
+      imageError: imageError
+    });
+    imageLoaded = true;
+    imageError = false;
+    console.log('🖼️ [ExternalLinkEmbed] State after load:', {
+      imageLoaded: imageLoaded,
+      imageError: imageError
+    });
+  };
+
+  // 画像読み込みエラーハンドラー
+  const handleImageError = (event: Event) => {
+    console.log('🚫 [ExternalLinkEmbed] Image load error:', {
+      url: linkData().thumb,
+      error: event,
+      imageLoaded: imageLoaded,
+      imageError: imageError
+    });
+    imageLoaded = false;
+    imageError = true;
+    console.log('🚫 [ExternalLinkEmbed] State after error:', {
+      imageLoaded: imageLoaded,
+      imageError: imageError
+    });
+  };
+
+  // タイトルとディスクリプションの切り詰め
+  const truncateText = (text: string, maxLength: number): string => {
+    if (text.length <= maxLength) return text;
+    return text.slice(0, maxLength - 3) + '...';
+  };
+
+  // キーボードイベントハンドラー
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      handleLinkClick(event as unknown as MouseEvent);
+    }
+  };
+</script>
+
+<!-- 外部リンク埋め込みコンテナ -->
+<div 
+  class="w-full {additionalClass}"
+  style="max-width: {displayOptions.maxWidth}px;"
+>
+  <!-- リンクプレビューカード -->
+  <div
+    class="group border border-subtle bg-card hover:bg-muted/5 transition-colors cursor-pointer {displayOptions.rounded ? 'rounded-lg' : ''} overflow-hidden {displayOptions.shadow ? 'shadow-sm hover:shadow-md' : ''}"
+    role="button"
+    tabindex="0"
+    onclick={handleLinkClick}
+    onkeydown={handleKeyDown}
+    aria-label="外部リンク: {linkData().title}"
+  >
+    <!-- サムネイル付きレイアウト -->
+    {#if linkData().thumb && !imageError}
+      <div class="flex">
+        <!-- サムネイル画像 -->
+        <div 
+          class="relative w-32 h-24 flex-shrink-0 bg-muted overflow-hidden cursor-pointer"
+          onclick={handleImageClick}
+          role="button"
+          tabindex="0"
+          aria-label="リンクのサムネイル画像"
+          onkeydown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              handleImageClick(e as unknown as MouseEvent);
+            }
+          }}
+        >
+          <img
+            src={linkData().thumb}
+            alt=""
+            class="w-full h-full object-cover transition-all duration-200 {imageLoaded ? 'opacity-100' : 'opacity-0'} group-hover:scale-105"
+            loading={displayOptions.lazy ? 'lazy' : 'eager'}
+            onload={handleImageLoad}
+            onerror={handleImageError}
+            decoding="async"
+          />
+          
+          <!-- 画像読み込み中プレースホルダー -->
+          {#if !imageLoaded && !imageError}
+            <div class="absolute inset-0 bg-muted animate-pulse flex items-center justify-center">
+              <Icon icon={ICONS.IMAGE} size="md" color="secondary" />
+            </div>
+          {:else if imageError}
+            <!-- 画像読み込みエラー表示 -->
+            <div class="absolute inset-0 bg-muted flex items-center justify-center">
+              <Icon icon={ICONS.IMAGE_OFF} size="md" color="inactive" />
+            </div>
+          {/if}
+          
+          <!-- 外部リンクアイコンオーバーレイ -->
+          <div class="absolute top-1 right-1 w-5 h-5 bg-black/60 rounded-full flex items-center justify-center">
+            <Icon icon={ICONS.OPEN_IN_NEW} size="xs" color="white" />
+          </div>
+        </div>
+        
+        <!-- テキストコンテンツ -->
+        <div class="flex-1 p-3 min-w-0">
+          <div class="space-y-1">
+            <!-- タイトル -->
+            <h3 class="font-medium text-themed text-sm leading-tight line-clamp-2">
+              {truncateText(linkData().title, 80)}
+            </h3>
+            
+            <!-- 説明文 -->
+            {#if linkData().description}
+              <p class="text-secondary text-xs leading-relaxed line-clamp-2">
+                {truncateText(linkData().description, 120)}
+              </p>
+            {/if}
+            
+            <!-- ドメイン -->
+            <div class="flex items-center gap-1 mt-2">
+              <Icon icon={ICONS.LANGUAGE} size="xs" color="inactive" />
+              <span class="text-inactive text-xs truncate">
+                {domain()}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    {:else}
+      <!-- サムネイルなしレイアウト -->
+      <div class="p-3">
+        <div class="space-y-2">
+          <!-- ヘッダー -->
+          <div class="flex items-start justify-between gap-2">
+            <div class="flex-1 min-w-0">
+              <!-- タイトル -->
+              <h3 class="font-medium text-themed text-sm leading-tight line-clamp-2">
+                {truncateText(linkData().title, 100)}
+              </h3>
+              
+              <!-- ドメイン -->
+              <div class="flex items-center gap-1 mt-1">
+                <Icon icon={ICONS.LANGUAGE} size="xs" color="inactive" />
+                <span class="text-inactive text-xs truncate">
+                  {domain()}
+                </span>
+              </div>
+            </div>
+            
+            <!-- 外部リンクアイコン -->
+            <div class="flex-shrink-0 w-8 h-8 bg-muted rounded-full flex items-center justify-center">
+              <Icon icon={ICONS.OPEN_IN_NEW} size="sm" color="secondary" />
+            </div>
+          </div>
+          
+          <!-- 説明文 -->
+          {#if linkData().description}
+            <p class="text-secondary text-xs leading-relaxed line-clamp-3">
+              {truncateText(linkData().description, 200)}
+            </p>
+          {/if}
+        </div>
+      </div>
+    {/if}
+  </div>
+</div>
+
+<!--
+使用例:
+
+基本的な使用:
+<ExternalLinkEmbed {embed} />
+
+カスタムクリックハンドラー:
+<ExternalLinkEmbed 
+  {embed}
+  onLinkClick={(url, event) => {
+    // カスタムリンク処理
+    window.open(url, '_blank');
+  }}
+  onImageClick={(imageUrl, linkUrl, event) => {
+    // 画像クリック時の独自処理
+    openImageViewer(imageUrl);
+  }}
+/>
+
+表示オプション:
+<ExternalLinkEmbed 
+  {embed}
+  options={{
+    maxWidth: 600,
+    rounded: true,
+    shadow: true,
+    lazy: true
+  }}
+/>
+-->
+
+<style>
+  /* 複数行テキストの切り詰め */
+  .line-clamp-2 {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
+  }
+  
+  .line-clamp-3 {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    overflow: hidden;
+  }
+  
+  /* ホバー時のスケール効果を滑らかに */
+  .group:hover img {
+    transform: scale(1.05);
+  }
+  
+  /* フォーカス状態の視覚化 */
+  [role="button"]:focus-visible {
+    outline: 2px solid rgb(59 130 246 / 0.5);
+    outline-offset: 2px;
+  }
+  
+  /* 画像の最適化 */
+  img {
+    image-rendering: -webkit-optimize-contrast;
+    image-rendering: crisp-edges;
+  }
+</style>

--- a/moodeSky/src/lib/components/embeddings/ImageEmbed.svelte
+++ b/moodeSky/src/lib/components/embeddings/ImageEmbed.svelte
@@ -1,0 +1,278 @@
+<!--
+  ImageEmbed.svelte
+  画像埋め込みコンポーネント
+  app.bsky.embed.images および app.bsky.embed.images#view 対応
+-->
+<script lang="ts">
+  import type { ImageEmbed, ImageEmbedView, EmbedDisplayOptions, AspectRatio } from './types.js';
+  import { DEFAULT_EMBED_DISPLAY_OPTIONS } from './types.js';
+
+  interface Props {
+    /** 画像埋め込みデータ */
+    embed: ImageEmbed | ImageEmbedView;
+    /** 表示オプション */
+    options?: Partial<EmbedDisplayOptions>;
+    /** 追加CSSクラス */
+    class?: string;
+    /** クリック時の処理 */
+    onClick?: (imageIndex: number, imageUrl: string) => void;
+  }
+
+  const { 
+    embed, 
+    options = {}, 
+    class: additionalClass = '',
+    onClick
+  }: Props = $props();
+
+  // 表示設定のマージ
+  const displayOptions = $derived({ ...DEFAULT_EMBED_DISPLAY_OPTIONS, ...options });
+
+  // 画像データの正規化（embed vs embedView の違いを吸収）
+  const images = $derived(() => {
+    return embed.images.map((img, index) => ({
+      id: `img-${index}`,
+      url: 'thumb' in img ? img.thumb : '#', // View の場合は thumb URL
+      fullUrl: 'fullsize' in img ? img.fullsize : '#', // View の場合は fullsize URL  
+      alt: img.alt || '',
+      aspectRatio: img.aspectRatio
+    }));
+  });
+
+  // グリッドレイアウトクラスの計算
+  const gridClass = $derived(() => {
+    const count = images().length;
+    if (count === 1) return 'grid-cols-1';
+    if (count === 2) return 'grid-cols-2';
+    if (count === 3) return 'grid-cols-2'; // 3枚の場合は 2+1 レイアウト
+    return 'grid-cols-2'; // 4枚以上は 2x2
+  });
+
+  // 個別画像のスタイルクラス
+  const getImageClass = (index: number, totalCount: number) => {
+    let baseClass = 'relative overflow-hidden transition-all duration-200';
+    
+    // 角丸設定
+    if (displayOptions.rounded) {
+      baseClass += ' rounded-lg';
+    }
+    
+    // ホバー効果
+    if (displayOptions.interactive) {
+      baseClass += ' hover:scale-[1.02] hover:shadow-lg';
+    }
+    
+    // クリック可能な場合
+    if (displayOptions.clickable && onClick) {
+      baseClass += ' cursor-pointer focus:outline-none focus:ring-2 focus:ring-blue-500/50';
+    }
+    
+    // 3枚レイアウトの特殊処理
+    if (totalCount === 3 && index === 2) {
+      baseClass += ' col-span-2'; // 3枚目は横幅2倍
+    }
+    
+    return baseClass;
+  };
+
+  // アスペクト比スタイルの計算
+  const getAspectRatioStyle = (aspectRatio?: AspectRatio) => {
+    if (!aspectRatio) return '';
+    const ratio = (aspectRatio.height / aspectRatio.width) * 100;
+    return `aspect-ratio: ${aspectRatio.width}/${aspectRatio.height};`;
+  };
+
+  // 画像クリックハンドラー
+  const handleImageClick = (index: number, imageUrl: string) => {
+    if (onClick && displayOptions.clickable) {
+      onClick(index, imageUrl);
+    }
+  };
+
+  // 画像の読み込みエラーハンドラー
+  const handleImageError = (event: Event) => {
+    const img = event.target as HTMLImageElement;
+    const imageUrl = img.src;
+    
+    console.log('🚫 [ImageEmbed] Image load error:', {
+      url: imageUrl,
+      error: event,
+      loadState: imageLoadStates[imageUrl],
+      errorState: imageErrorStates[imageUrl]
+    });
+    
+    img.style.display = 'none';
+    imageLoadStates[imageUrl] = false;
+    imageErrorStates[imageUrl] = true;
+    
+    console.log('🚫 [ImageEmbed] State after error:', {
+      imageLoadStates,
+      imageErrorStates
+    });
+    // エラー時のフォールバック表示は親要素で処理
+  };
+
+  // 画像読み込み状態管理
+  let imageLoadStates = $state<Record<string, boolean>>({});
+  let imageErrorStates = $state<Record<string, boolean>>({});
+
+  // 画像の読み込み完了ハンドラー
+  const handleImageLoad = (event: Event) => {
+    const img = event.target as HTMLImageElement;
+    const imageUrl = img.src;
+    
+    console.log('🖼️ [ImageEmbed] Image loaded successfully:', {
+      url: imageUrl,
+      loadState: imageLoadStates[imageUrl]
+    });
+    
+    img.classList.add('opacity-100');
+    img.classList.remove('opacity-0');
+    imageLoadStates[imageUrl] = true;
+    imageErrorStates[imageUrl] = false;
+    
+    console.log('🖼️ [ImageEmbed] State after load:', {
+      imageLoadStates,
+      imageErrorStates
+    });
+  };
+</script>
+
+<!-- 画像埋め込みコンテナ -->
+<div 
+  class="w-full {additionalClass}"
+  style="max-width: {displayOptions.maxWidth}px;"
+>
+  <!-- 画像グリッド -->
+  <div class="grid {gridClass} gap-2">
+    {#each images() as image, index}
+      <!-- 個別画像コンテナ -->
+      <div
+        class={getImageClass(index, images().length)}
+        style={getAspectRatioStyle(image.aspectRatio)}
+        role={displayOptions.clickable ? "button" : undefined}
+        tabindex={displayOptions.clickable ? 0 : undefined}
+        aria-label={displayOptions.clickable ? `画像 ${index + 1} を表示` : undefined}
+        onclick={() => handleImageClick(index, image.fullUrl)}
+        onkeydown={(e) => {
+          if (displayOptions.clickable && (e.key === 'Enter' || e.key === ' ')) {
+            e.preventDefault();
+            handleImageClick(index, image.fullUrl);
+          }
+        }}
+      >
+        <!-- 画像要素 -->
+        <img
+          src={image.url}
+          alt={image.alt}
+          class="w-full h-full object-cover transition-opacity duration-300 opacity-0"
+          loading={displayOptions.lazy ? 'lazy' : 'eager'}
+          decoding="async"
+          onload={handleImageLoad}
+          onerror={handleImageError}
+        />
+        
+        <!-- alt テキストオーバーレイ（設定で有効な場合） -->
+        {#if displayOptions.showAlt && image.alt}
+          <div 
+            class="absolute bottom-0 left-0 right-0 bg-black/60 text-white text-sm p-2 backdrop-blur-sm"
+            aria-hidden="true"
+          >
+            {image.alt}
+          </div>
+        {/if}
+        
+        <!-- 読み込み中プレースホルダー -->
+        {#if !imageLoadStates[image.url] && !imageErrorStates[image.url]}
+          <div 
+            class="absolute inset-0 bg-muted animate-pulse flex items-center justify-center"
+            aria-hidden="true"
+          >
+            <div class="w-8 h-8 border-2 border-secondary/30 border-t-secondary rounded-full animate-spin"></div>
+          </div>
+        {:else if imageErrorStates[image.url]}
+          <!-- 画像読み込みエラー表示 -->
+          <div 
+            class="absolute inset-0 bg-muted flex items-center justify-center"
+            aria-hidden="true"
+          >
+            <div class="text-center">
+              <Icon icon={ICONS.IMAGE_OFF} size="lg" color="inactive" />
+              <p class="text-xs text-inactive mt-1">読み込み失敗</p>
+            </div>
+          </div>
+        {/if}
+      </div>
+    {/each}
+  </div>
+  
+  <!-- 画像枚数インジケーター（3枚以上の場合） -->
+  {#if images().length > 2}
+    <div class="mt-2 text-center">
+      <span class="text-secondary text-sm">
+        {images().length} 枚の画像
+      </span>
+    </div>
+  {/if}
+</div>
+
+<!--
+使用例:
+
+基本的な使用:
+<ImageEmbed {embed} />
+
+カスタムオプション付き:
+<ImageEmbed 
+  {embed}
+  options={{
+    maxWidth: 800,
+    rounded: true,
+    interactive: true,
+    clickable: true
+  }}
+  onClick={(index, url) => openLightbox(url)}
+/>
+
+非インタラクティブ:
+<ImageEmbed 
+  {embed}
+  options={{
+    interactive: false,
+    clickable: false,
+    showAlt: false
+  }}
+/>
+-->
+
+<style>
+  /* アスペクト比維持のためのCSS */
+  .grid > div {
+    min-height: 120px; /* 最小高さ確保 */
+  }
+  
+  /* 3枚レイアウトの調整 */
+  .grid-cols-2 > div:nth-child(3) {
+    grid-column: span 2;
+    max-height: 200px; /* 3枚目の高さ制限 */
+  }
+  
+  /* フォーカス状態の視覚化 */
+  [role="button"]:focus-visible {
+    outline: 2px solid rgb(59 130 246 / 0.5);
+    outline-offset: 2px;
+  }
+  
+  /* 画像のスムーズな表示 */
+  img {
+    image-rendering: -webkit-optimize-contrast;
+    image-rendering: crisp-edges;
+  }
+  
+  /* ダークモード対応 */
+  @media (prefers-color-scheme: dark) {
+    .bg-black\/60 {
+      background-color: rgba(0, 0, 0, 0.8);
+    }
+  }
+</style>

--- a/moodeSky/src/lib/components/embeddings/ImageEmbed.svelte
+++ b/moodeSky/src/lib/components/embeddings/ImageEmbed.svelte
@@ -194,7 +194,7 @@
   style="max-width: {displayOptions.maxWidth}px;"
 >
   <!-- 16:9美しい画像グリッド -->
-  <div class="relative w-full aspect-[16/9] {gridLayoutClass()}">
+  <div class="relative w-full aspect-[16/9] border border-subtle rounded-lg overflow-hidden {gridLayoutClass()}">
     {#each images().slice(0, 4) as image, index}
       <!-- 個別画像コンテナ -->
       <div

--- a/moodeSky/src/lib/components/embeddings/RecordEmbed.svelte
+++ b/moodeSky/src/lib/components/embeddings/RecordEmbed.svelte
@@ -1,0 +1,305 @@
+<!--
+  RecordEmbed.svelte
+  記録埋め込みコンポーネント（引用投稿）
+  app.bsky.embed.record および app.bsky.embed.record#view 対応
+  他のBluesky投稿への参照・引用表示
+-->
+<script lang="ts">
+  import Avatar from '$lib/components/Avatar.svelte';
+  import Icon from '$lib/components/Icon.svelte';
+  import { ICONS } from '$lib/types/icon.js';
+  import { formatRelativeTime } from '$lib/utils/relativeTime.js';
+  import type { RecordEmbed, RecordEmbedView, EmbedDisplayOptions } from './types.js';
+  import type { EmbedView } from './types.js';
+  import { DEFAULT_EMBED_DISPLAY_OPTIONS } from './types.js';
+
+  interface Props {
+    /** 記録埋め込みデータ */
+    embed: RecordEmbed | RecordEmbedView;
+    /** 表示オプション */
+    options?: Partial<EmbedDisplayOptions>;
+    /** 追加CSSクラス */
+    class?: string;
+    /** 引用投稿クリック時の処理 */
+    onPostClick?: (uri: string, cid: string) => void;
+    /** 作者クリック時の処理 */
+    onAuthorClick?: (did: string, handle: string) => void;
+    /** 最大ネスト深度（無限ループ防止） */
+    maxDepth?: number;
+    /** 現在のネスト深度 */
+    currentDepth?: number;
+  }
+
+  const { 
+    embed, 
+    options = {}, 
+    class: additionalClass = '',
+    onPostClick,
+    onAuthorClick,
+    maxDepth = 3,
+    currentDepth = 0
+  }: Props = $props();
+
+  // 表示設定のマージ
+  const displayOptions = $derived({ ...DEFAULT_EMBED_DISPLAY_OPTIONS, ...options });
+
+  // 記録データの正規化（embed vs embedView の違いを吸収）
+  const recordData = $derived(() => {
+    if ('record' in embed && typeof embed.record === 'object' && 'author' in embed.record) {
+      // RecordEmbedView の場合
+      const recordView = embed as RecordEmbedView;
+      return {
+        uri: recordView.record.uri,
+        cid: recordView.record.cid,
+        author: recordView.record.author,
+        value: recordView.record.value,
+        indexedAt: recordView.record.indexedAt,
+        embeds: recordView.record.embeds || []
+      };
+    } else {
+      // RecordEmbed の場合（参照データのみ）
+      const recordEmbed = embed as RecordEmbed;
+      return {
+        uri: recordEmbed.record.uri,
+        cid: recordEmbed.record.cid,
+        author: null, // View データがないため不明
+        value: null,
+        indexedAt: null,
+        embeds: []
+      };
+    }
+  });
+
+  // 投稿テキストを抽出（app.bsky.feed.post の場合）
+  const postText = $derived(() => {
+    if (!recordData().value || typeof recordData().value !== 'object') {
+      return '投稿を読み込めませんでした';
+    }
+    
+    const value = recordData().value as any;
+    if (value.$type === 'app.bsky.feed.post' && typeof value.text === 'string') {
+      return value.text;
+    }
+    
+    return '不明な記録タイプ';
+  });
+
+  // 相対時間表示
+  const relativeTime = $derived(() => {
+    if (!recordData().indexedAt) return '';
+    return formatRelativeTime(recordData().indexedAt || '');
+  });
+
+  // 作者情報の有効性チェック
+  const hasAuthor = $derived(() => recordData().author !== null);
+
+  // 投稿クリックハンドラー
+  const handlePostClick = () => {
+    if (onPostClick && displayOptions.clickable) {
+      onPostClick(recordData().uri, recordData().cid);
+    }
+  };
+
+  // 作者クリックハンドラー
+  const handleAuthorClick = (event: MouseEvent) => {
+    event.stopPropagation();
+    const author = recordData().author;
+    if (onAuthorClick && author) {
+      onAuthorClick(author.did, author.handle);
+    }
+  };
+
+  // キーボードイベントハンドラー
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      handlePostClick();
+    }
+  };
+
+  // ネストが深すぎる場合の判定
+  const isTooDeep = $derived(() => currentDepth >= maxDepth);
+
+  // 短縮表示用のテキスト切り詰め
+  const truncateText = (text: string, maxLength: number): string => {
+    if (text.length <= maxLength) return text;
+    return text.slice(0, maxLength - 3) + '...';
+  };
+</script>
+
+<!-- 記録埋め込みコンテナ -->
+<div 
+  class="w-full {additionalClass}"
+  style="max-width: {displayOptions.maxWidth}px;"
+>
+  <!-- 引用投稿カード -->
+  <div
+    class="border border-subtle bg-muted/5 hover:bg-muted/10 transition-colors {displayOptions.rounded ? 'rounded-lg' : ''} overflow-hidden {displayOptions.clickable ? 'cursor-pointer' : ''}"
+    role={displayOptions.clickable ? "button" : undefined}
+    tabindex={displayOptions.clickable ? 0 : undefined}
+    onclick={handlePostClick}
+    onkeydown={handleKeyDown}
+    aria-label={hasAuthor() ? `@${recordData().author?.handle}の投稿を引用` : '引用投稿'}
+  >
+    {#if hasAuthor() && !isTooDeep()}
+      <!-- 完全なView データがある場合 -->
+      <div class="p-3">
+        <!-- ヘッダー: 作者情報 + 日時 -->
+        <header class="flex items-start gap-2 mb-2">
+          <!-- アバター -->
+          <button
+            class="flex-shrink-0 hover:opacity-80 transition-opacity"
+            onclick={handleAuthorClick}
+            aria-label="@{recordData().author?.handle}のプロフィール"
+          >
+            <Avatar 
+              src={recordData().author?.avatar}
+              displayName={recordData().author?.displayName}
+              handle={recordData().author?.handle}
+              size="sm"
+            />
+          </button>
+          
+          <!-- 作者情報と日時 -->
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center gap-2">
+              <!-- 表示名 -->
+              {#if recordData().author?.displayName}
+                <button
+                  class="font-medium text-themed text-sm hover:underline truncate"
+                  onclick={handleAuthorClick}
+                >
+                  {recordData().author?.displayName}
+                </button>
+              {/if}
+              
+              <!-- ハンドル -->
+              <button
+                class="text-secondary text-sm hover:underline truncate"
+                onclick={handleAuthorClick}
+              >
+                @{recordData().author?.handle}
+              </button>
+              
+              <!-- 時間 -->
+              {#if relativeTime()}
+                <span class="text-secondary text-sm flex-shrink-0">
+                  · {relativeTime()}
+                </span>
+              {/if}
+            </div>
+          </div>
+          
+          <!-- 引用アイコン -->
+          <div class="flex-shrink-0">
+            <Icon icon={ICONS.LINK} size="xs" color="secondary" />
+          </div>
+        </header>
+        
+        <!-- 投稿内容 -->
+        <div class="text-themed text-sm leading-relaxed mb-2">
+          {truncateText(postText(), 280)}
+        </div>
+        
+        <!-- ネストされた埋め込み（深度制限あり） -->
+        {#if recordData().embeds.length > 0 && !isTooDeep()}
+          <div class="mt-2 ml-2 border-l-2 border-subtle pl-2">
+            {#each recordData().embeds as nestedEmbed}
+              <!-- 再帰的な埋め込み表示（簡略化） -->
+              <div class="text-xs text-secondary">
+                <Icon icon={ICONS.ATTACH_FILE} size="xs" color="inactive" />
+                埋め込みコンテンツ
+              </div>
+            {/each}
+          </div>
+        {/if}
+      </div>
+    {:else if isTooDeep()}
+      <!-- ネストが深すぎる場合の簡略表示 -->
+      <div class="p-3 text-center">
+        <Icon icon={ICONS.MORE_HORIZ} size="md" color="secondary" class="mx-auto mb-1" />
+        <p class="text-secondary text-sm">引用が続いています...</p>
+        <button
+          class="text-primary text-xs hover:underline mt-1"
+          onclick={handlePostClick}
+        >
+          投稿を表示
+        </button>
+      </div>
+    {:else}
+      <!-- View データがない場合（参照のみ） -->
+      <div class="p-3">
+        <div class="flex items-center gap-2">
+          <Icon icon={ICONS.LINK} size="sm" color="secondary" />
+          <div class="flex-1">
+            <p class="text-secondary text-sm">引用投稿</p>
+            <p class="text-inactive text-xs font-mono truncate">
+              {recordData().uri}
+            </p>
+          </div>
+          <button
+            class="text-primary text-xs hover:underline"
+            onclick={handlePostClick}
+          >
+            表示
+          </button>
+        </div>
+      </div>
+    {/if}
+  </div>
+</div>
+
+<!--
+使用例:
+
+基本的な使用:
+<RecordEmbed {embed} />
+
+クリックハンドラー付き:
+<RecordEmbed 
+  {embed}
+  onPostClick={(uri, cid) => navigateToPost(uri)}
+  onAuthorClick={(did, handle) => navigateToProfile(handle)}
+/>
+
+ネスト深度制限:
+<RecordEmbed 
+  {embed}
+  maxDepth={2}
+  currentDepth={1}
+/>
+
+非インタラクティブ:
+<RecordEmbed 
+  {embed}
+  options={{
+    clickable: false,
+    interactive: false
+  }}
+/>
+-->
+
+<style>
+  /* フォーカス状態の視覚化 */
+  [role="button"]:focus-visible {
+    outline: 2px solid rgb(59 130 246 / 0.5);
+    outline-offset: 2px;
+  }
+  
+  /* アバターボタンのホバー効果 */
+  button:hover img {
+    transform: scale(1.05);
+  }
+  
+  /* 引用カードの境界線調整 */
+  .border-l-2 {
+    border-left-width: 2px;
+  }
+  
+  /* テキストの切り詰め */
+  .truncate {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+</style>

--- a/moodeSky/src/lib/components/embeddings/RecordWithMediaEmbed.svelte
+++ b/moodeSky/src/lib/components/embeddings/RecordWithMediaEmbed.svelte
@@ -1,0 +1,313 @@
+<!--
+  RecordWithMediaEmbed.svelte
+  記録+メディア複合埋め込みコンポーネント
+  app.bsky.embed.recordWithMedia および app.bsky.embed.recordWithMedia#view 対応
+  引用投稿にメディア（画像・動画・外部リンク）を組み合わせて表示
+-->
+<script lang="ts">
+  import ImageEmbed from './ImageEmbed.svelte';
+  import VideoEmbed from './VideoEmbed.svelte';
+  import ExternalLinkEmbed from './ExternalLinkEmbed.svelte';
+  import RecordEmbed from './RecordEmbed.svelte';
+  import type { 
+    RecordWithMediaEmbed, 
+    RecordWithMediaEmbedView, 
+    EmbedDisplayOptions,
+    ImageEmbed as ImageEmbedType,
+    ImageEmbedView,
+    VideoEmbed as VideoEmbedType,
+    VideoEmbedView,
+    ExternalEmbed as ExternalEmbedType,
+    ExternalEmbedView
+  } from './types.js';
+  import { 
+    DEFAULT_EMBED_DISPLAY_OPTIONS,
+    isImageEmbed,
+    isImageEmbedView,
+    isVideoEmbed,
+    isVideoEmbedView,
+    isExternalEmbed,
+    isExternalEmbedView
+  } from './types.js';
+
+  interface Props {
+    /** 記録+メディア埋め込みデータ */
+    embed: RecordWithMediaEmbed | RecordWithMediaEmbedView;
+    /** 表示オプション */
+    options?: Partial<EmbedDisplayOptions>;
+    /** 追加CSSクラス */
+    class?: string;
+    /** 引用投稿クリック時の処理 */
+    onPostClick?: (uri: string, cid: string) => void;
+    /** 作者クリック時の処理 */
+    onAuthorClick?: (did: string, handle: string) => void;
+    /** メディアクリック時の処理 */
+    onMediaClick?: (mediaUrl: string, mediaType: string) => void;
+    /** 外部リンククリック時の処理 */
+    onLinkClick?: (url: string, event: MouseEvent) => void;
+    /** レイアウト方向（vertical: 縦, horizontal: 横） */
+    layout?: 'vertical' | 'horizontal';
+  }
+
+  const { 
+    embed, 
+    options = {}, 
+    class: additionalClass = '',
+    onPostClick,
+    onAuthorClick,
+    onMediaClick,
+    onLinkClick,
+    layout = 'vertical'
+  }: Props = $props();
+
+  // 表示設定のマージ
+  const displayOptions = $derived({ ...DEFAULT_EMBED_DISPLAY_OPTIONS, ...options });
+
+  // 記録データの抽出
+  const recordData = $derived(() => ({
+    uri: embed.record.uri,
+    cid: embed.record.cid,
+    // RecordWithMediaEmbedView の場合は追加データが含まれる
+    ...('author' in embed.record ? embed.record : {})
+  }));
+
+  // メディアデータの抽出と型判定
+  const mediaData = $derived(() => {
+    const media = embed.media as any; // 型安全性のため
+    
+    if (isImageEmbed(media)) {
+      return { type: 'image' as const, data: media };
+    } else if (isImageEmbedView(media)) {
+      return { type: 'image' as const, data: media };
+    } else if (isVideoEmbed(media)) {
+      return { type: 'video' as const, data: media };
+    } else if (isVideoEmbedView(media)) {
+      return { type: 'video' as const, data: media };
+    } else if (isExternalEmbed(media)) {
+      return { type: 'external' as const, data: media };
+    } else if (isExternalEmbedView(media)) {
+      return { type: 'external' as const, data: media };
+    }
+    
+    return { type: 'unknown' as const, data: media };
+  });
+
+  // レイアウトクラスの計算
+  const containerClass = $derived(() => {
+    let baseClass = 'w-full space-y-3';
+    
+    if (layout === 'horizontal' && mediaData().type !== 'video') {
+      // 横レイアウト（動画以外）
+      baseClass = 'w-full flex gap-3';
+    }
+    
+    return `${baseClass} ${additionalClass}`;
+  });
+
+  // 記録部分のクラス
+  const recordClass = $derived(() => {
+    if (layout === 'horizontal' && mediaData().type !== 'video') {
+      return 'flex-1 min-w-0'; // 横レイアウトでは柔軟な幅
+    }
+    return 'w-full';
+  });
+
+  // メディア部分のクラス
+  const mediaClass = $derived(() => {
+    if (layout === 'horizontal' && mediaData().type !== 'video') {
+      if (mediaData().type === 'external') {
+        return 'w-1/3 max-w-xs'; // 外部リンクは小さめ
+      }
+      return 'w-1/2'; // 画像は半分
+    }
+    return 'w-full';
+  });
+
+  // メディア用の表示オプション
+  const mediaOptions = $derived(() => ({
+    ...displayOptions,
+    maxWidth: layout === 'horizontal' ? 300 : displayOptions.maxWidth,
+    rounded: true
+  }));
+
+  // 記録用の表示オプション  
+  const recordOptions = $derived(() => ({
+    ...displayOptions,
+    maxWidth: layout === 'horizontal' ? undefined : displayOptions.maxWidth
+  }));
+
+  // メディアクリックハンドラー
+  const handleMediaClick = (mediaUrl: string) => {
+    if (onMediaClick) {
+      onMediaClick(mediaUrl, mediaData().type);
+    }
+  };
+
+  // 画像クリックハンドラー
+  const handleImageClick = (imageIndex: number, imageUrl: string) => {
+    handleMediaClick(imageUrl);
+  };
+
+  // 外部リンククリックハンドラー
+  const handleLinkClick = (url: string, event: MouseEvent) => {
+    if (onLinkClick) {
+      event.preventDefault();
+      onLinkClick(url, event);
+    }
+  };
+</script>
+
+<!-- 記録+メディア埋め込みコンテナ -->
+<div 
+  class={containerClass()}
+  style="max-width: {displayOptions.maxWidth}px;"
+>
+  {#if layout === 'vertical'}
+    <!-- 縦レイアウト: メディア → 記録 -->
+    
+    <!-- メディア部分 -->
+    <div class={mediaClass()}>
+      {#if mediaData().type === 'image'}
+        <ImageEmbed 
+          embed={mediaData().data as ImageEmbedType | ImageEmbedView}
+          options={mediaOptions()}
+          onClick={handleImageClick}
+        />
+      {:else if mediaData().type === 'video'}
+        <VideoEmbed 
+          embed={mediaData().data as VideoEmbedType | VideoEmbedView}
+          options={mediaOptions()}
+        />
+      {:else if mediaData().type === 'external'}
+        <ExternalLinkEmbed 
+          embed={mediaData().data as ExternalEmbedType | ExternalEmbedView}
+          options={mediaOptions()}
+          onLinkClick={handleLinkClick}
+        />
+      {:else}
+        <!-- 未知のメディアタイプ -->
+        <div class="p-3 border border-subtle rounded-lg bg-muted/5 text-center">
+          <p class="text-secondary text-sm">未対応のメディアタイプ</p>
+        </div>
+      {/if}
+    </div>
+    
+    <!-- 記録部分 -->
+    <div class={recordClass()}>
+      <RecordEmbed 
+        embed={{ $type: 'app.bsky.embed.record', record: recordData() }}
+        options={recordOptions()}
+        {onPostClick}
+        {onAuthorClick}
+      />
+    </div>
+    
+  {:else}
+    <!-- 横レイアウト: 記録 | メディア -->
+    
+    <!-- 記録部分 -->
+    <div class={recordClass()}>
+      <RecordEmbed 
+        embed={{ $type: 'app.bsky.embed.record', record: recordData() }}
+        options={recordOptions()}
+        {onPostClick}
+        {onAuthorClick}
+      />
+    </div>
+    
+    <!-- メディア部分 -->
+    <div class={mediaClass()}>
+      {#if mediaData().type === 'image'}
+        <ImageEmbed 
+          embed={mediaData().data as ImageEmbedType | ImageEmbedView}
+          options={mediaOptions()}
+          onClick={handleImageClick}
+        />
+      {:else if mediaData().type === 'video'}
+        <!-- 横レイアウトでも動画は縦に表示 -->
+        <div class="w-full">
+          <VideoEmbed 
+            embed={mediaData().data as VideoEmbedType | VideoEmbedView}
+            options={{ ...mediaOptions(), maxWidth: displayOptions.maxWidth }}
+          />
+        </div>
+      {:else if mediaData().type === 'external'}
+        <ExternalLinkEmbed 
+          embed={mediaData().data as ExternalEmbedType | ExternalEmbedView}
+          options={mediaOptions()}
+          onLinkClick={handleLinkClick}
+        />
+      {:else}
+        <!-- 未知のメディアタイプ -->
+        <div class="p-2 border border-subtle rounded-lg bg-muted/5 text-center">
+          <p class="text-secondary text-xs">未対応</p>
+        </div>
+      {/if}
+    </div>
+  {/if}
+</div>
+
+<!--
+使用例:
+
+基本的な使用（縦レイアウト）:
+<RecordWithMediaEmbed {embed} />
+
+横レイアウト:
+<RecordWithMediaEmbed 
+  {embed}
+  layout="horizontal"
+/>
+
+すべてのハンドラー付き:
+<RecordWithMediaEmbed 
+  {embed}
+  onPostClick={(uri, cid) => navigateToPost(uri)}
+  onAuthorClick={(did, handle) => navigateToProfile(handle)}
+  onMediaClick={(url, type) => openMediaViewer(url, type)}
+  onLinkClick={(url) => window.open(url, '_blank')}
+/>
+
+カスタムオプション:
+<RecordWithMediaEmbed 
+  {embed}
+  layout="vertical"
+  options={{
+    maxWidth: 800,
+    rounded: true,
+    interactive: true,
+    clickable: true
+  }}
+/>
+-->
+
+<style>
+  /* レスポンシブ調整 */
+  @media (max-width: 640px) {
+    /* 小画面では常に縦レイアウト */
+    .flex {
+      flex-direction: column;
+    }
+    
+    .w-1\/2,
+    .w-1\/3 {
+      width: 100%;
+      max-width: none;
+    }
+  }
+  
+  /* メディアとテキストの調和 */
+  .space-y-3 > * + * {
+    margin-top: 0.75rem;
+  }
+  
+  /* 横レイアウトでの最小幅確保 */
+  .min-w-0 {
+    min-width: 0;
+  }
+  
+  /* フレックスアイテムの調整 */
+  .flex-1 {
+    flex: 1 1 0%;
+  }
+</style>

--- a/moodeSky/src/lib/components/embeddings/VideoEmbed.svelte
+++ b/moodeSky/src/lib/components/embeddings/VideoEmbed.svelte
@@ -1,0 +1,427 @@
+<!--
+  VideoEmbed.svelte
+  動画埋め込みコンポーネント
+  app.bsky.embed.video および app.bsky.embed.video#view 対応
+  最大100MBサイズ、HLS (m3u8) プレイリスト、キャプション対応
+-->
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import Icon from '$lib/components/Icon.svelte';
+  import { ICONS } from '$lib/types/icon.js';
+  import type { VideoEmbed, VideoEmbedView, EmbedDisplayOptions, AspectRatio } from './types.js';
+  import { DEFAULT_EMBED_DISPLAY_OPTIONS } from './types.js';
+
+  interface Props {
+    /** 動画埋め込みデータ */
+    embed: VideoEmbed | VideoEmbedView;
+    /** 表示オプション */
+    options?: Partial<EmbedDisplayOptions>;
+    /** 追加CSSクラス */
+    class?: string;
+    /** 自動再生（デフォルト: false） */
+    autoplay?: boolean;
+    /** ミュート状態（デフォルト: true） */
+    muted?: boolean;
+    /** ループ再生（デフォルト: false） */
+    loop?: boolean;
+  }
+
+  const { 
+    embed, 
+    options = {}, 
+    class: additionalClass = '',
+    autoplay = false,
+    muted = true,
+    loop = false
+  }: Props = $props();
+
+  // 内部状態
+  let videoElement: HTMLVideoElement;
+  let isPlaying = $state(false);
+  let isLoading = $state(true);
+  let hasError = $state(false);
+  let currentTime = $state(0);
+  let duration = $state(0);
+  let volume = $state(muted ? 0 : 0.5);
+  let showControls = $state(false);
+  let isFullscreen = $state(false);
+
+  // 表示設定のマージ
+  const displayOptions = $derived({ ...DEFAULT_EMBED_DISPLAY_OPTIONS, ...options });
+
+  // 動画データの正規化（embed vs embedView の違いを吸収）
+  const videoData = $derived(() => ({
+    url: 'playlist' in embed ? embed.playlist : '#', // View の場合は playlist URL (m3u8)
+    thumbnail: 'thumbnail' in embed ? embed.thumbnail : undefined,
+    alt: embed.alt || '',
+    aspectRatio: embed.aspectRatio,
+    cid: 'cid' in embed ? embed.cid : undefined
+  }));
+
+  // アスペクト比スタイルの計算
+  const getAspectRatioStyle = (aspectRatio?: AspectRatio) => {
+    if (!aspectRatio) return 'aspect-video'; // デフォルト 16:9
+    return `aspect-[${aspectRatio.width}/${aspectRatio.height}]`;
+  };
+
+  // 再生/一時停止トグル
+  const togglePlayPause = () => {
+    if (!videoElement) return;
+    
+    if (isPlaying) {
+      videoElement.pause();
+    } else {
+      videoElement.play();
+    }
+  };
+
+  // 音量調整
+  const handleVolumeChange = (event: Event) => {
+    const input = event.target as HTMLInputElement;
+    const newVolume = parseFloat(input.value);
+    volume = newVolume;
+    if (videoElement) {
+      videoElement.volume = newVolume;
+      videoElement.muted = newVolume === 0;
+    }
+  };
+
+  // シーク操作
+  const handleSeek = (event: Event) => {
+    const input = event.target as HTMLInputElement;
+    const newTime = parseFloat(input.value);
+    currentTime = newTime;
+    if (videoElement) {
+      videoElement.currentTime = newTime;
+    }
+  };
+
+  // フルスクリーン切り替え
+  const toggleFullscreen = async () => {
+    if (!videoElement) return;
+    
+    try {
+      if (isFullscreen) {
+        await document.exitFullscreen();
+      } else {
+        await videoElement.requestFullscreen();
+      }
+    } catch (error) {
+      console.warn('Fullscreen not supported:', error);
+    }
+  };
+
+  // 時間フォーマット
+  const formatTime = (seconds: number): string => {
+    const mins = Math.floor(seconds / 60);
+    const secs = Math.floor(seconds % 60);
+    return `${mins}:${secs.toString().padStart(2, '0')}`;
+  };
+
+  // コンポーネントマウント時の処理
+  onMount(() => {
+    if (!videoElement) return;
+
+    // イベントリスナーの設定
+    const handleLoadStart = () => {
+      isLoading = true;
+      hasError = false;
+    };
+
+    const handleLoadedData = () => {
+      isLoading = false;
+      duration = videoElement.duration;
+    };
+
+    const handlePlay = () => {
+      isPlaying = true;
+    };
+
+    const handlePause = () => {
+      isPlaying = false;
+    };
+
+    const handleTimeUpdate = () => {
+      currentTime = videoElement.currentTime;
+    };
+
+    const handleError = () => {
+      isLoading = false;
+      hasError = true;
+    };
+
+    const handleFullscreenChange = () => {
+      isFullscreen = !!document.fullscreenElement;
+    };
+
+    // イベントリスナー登録
+    videoElement.addEventListener('loadstart', handleLoadStart);
+    videoElement.addEventListener('loadeddata', handleLoadedData);
+    videoElement.addEventListener('play', handlePlay);
+    videoElement.addEventListener('pause', handlePause);
+    videoElement.addEventListener('timeupdate', handleTimeUpdate);
+    videoElement.addEventListener('error', handleError);
+    document.addEventListener('fullscreenchange', handleFullscreenChange);
+
+    // クリーンアップ
+    return () => {
+      videoElement?.removeEventListener('loadstart', handleLoadStart);
+      videoElement?.removeEventListener('loadeddata', handleLoadedData);
+      videoElement?.removeEventListener('play', handlePlay);
+      videoElement?.removeEventListener('pause', handlePause);
+      videoElement?.removeEventListener('timeupdate', handleTimeUpdate);
+      videoElement?.removeEventListener('error', handleError);
+      document.removeEventListener('fullscreenchange', handleFullscreenChange);
+    };
+  });
+</script>
+
+<!-- 動画埋め込みコンテナ -->
+<div 
+  class="relative w-full {additionalClass} {getAspectRatioStyle(videoData().aspectRatio)}"
+  style="max-width: {displayOptions.maxWidth}px; max-height: {displayOptions.maxHeight}px;"
+  onmouseenter={() => showControls = true}
+  onmouseleave={() => showControls = false}
+>
+  <!-- 動画要素 -->
+  <video
+    bind:this={videoElement}
+    class="w-full h-full object-cover {displayOptions.rounded ? 'rounded-lg' : ''}"
+    {autoplay}
+    {muted}
+    {loop}
+    playsinline
+    preload="metadata"
+    aria-label={videoData().alt || '動画コンテンツ'}
+    poster={videoData().thumbnail}
+  >
+    <!-- HLS プレイリスト (m3u8) の場合 -->
+    {#if videoData().url.endsWith('.m3u8')}
+      <source src={videoData().url} type="application/x-mpegURL" />
+    {:else}
+      <source src={videoData().url} type="video/mp4" />
+    {/if}
+    
+    <!-- キャプション（将来実装） -->
+    <!-- 
+    {#if embed.captions}
+      {#each embed.captions as caption}
+        <track kind="captions" src={caption.file} srclang={caption.lang} />
+      {/each}
+    {/if}
+    -->
+    
+    <!-- フォールバック -->
+    <p class="text-secondary">
+      お使いのブラウザは動画の再生をサポートしていません。
+    </p>
+  </video>
+
+  <!-- エラー表示 -->
+  {#if hasError}
+    <div class="absolute inset-0 bg-muted flex items-center justify-center {displayOptions.rounded ? 'rounded-lg' : ''}">
+      <div class="text-center text-secondary">
+        <Icon icon={ICONS.ERROR} size="lg" class="mx-auto mb-2" />
+        <p>動画を読み込めませんでした</p>
+      </div>
+    </div>
+  {/if}
+
+  <!-- 読み込み中表示 -->
+  {#if isLoading && !hasError}
+    <div class="absolute inset-0 bg-black/50 flex items-center justify-center">
+      <div class="text-center text-white">
+        <div class="w-8 h-8 border-2 border-white/30 border-t-white rounded-full animate-spin mx-auto mb-2"></div>
+        <p class="text-sm">読み込み中...</p>
+      </div>
+    </div>
+  {/if}
+
+  <!-- 中央再生ボタン -->
+  {#if !isPlaying && !isLoading && !hasError}
+    <button
+      class="absolute inset-0 flex items-center justify-center bg-black/30 hover:bg-black/50 transition-colors group"
+      onclick={togglePlayPause}
+      aria-label="動画を再生"
+    >
+      <div class="w-16 h-16 bg-white/90 rounded-full flex items-center justify-center group-hover:scale-110 transition-transform">
+        <Icon icon={ICONS.PLAY_ARROW} size="lg" color="themed" />
+      </div>
+    </button>
+  {/if}
+
+  <!-- コントロールバー -->
+  {#if showControls && !isLoading && !hasError}
+    <div class="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/80 to-transparent p-3 {displayOptions.rounded ? 'rounded-b-lg' : ''}">
+      <!-- プログレスバー -->
+      <div class="mb-2">
+        <input
+          type="range"
+          min="0"
+          max={duration || 0}
+          value={currentTime}
+          class="w-full h-1 bg-white/30 rounded-lg appearance-none cursor-pointer slider"
+          oninput={handleSeek}
+        />
+      </div>
+      
+      <!-- コントロールボタン群 -->
+      <div class="flex items-center justify-between text-white">
+        <!-- 左側コントロール -->
+        <div class="flex items-center gap-2">
+          <!-- 再生/一時停止 -->
+          <button
+            class="p-1 hover:bg-white/20 rounded transition-colors"
+            onclick={togglePlayPause}
+            aria-label={isPlaying ? '一時停止' : '再生'}
+          >
+            <Icon 
+              icon={isPlaying ? ICONS.PAUSE : ICONS.PLAY_ARROW} 
+              size="sm" 
+              color="white" 
+            />
+          </button>
+          
+          <!-- 音量 -->
+          <div class="flex items-center gap-1">
+            <button
+              class="p-1 hover:bg-white/20 rounded transition-colors"
+              onclick={() => {
+                const newMuted = volume > 0;
+                volume = newMuted ? 0 : 0.5;
+                if (videoElement) {
+                  videoElement.volume = volume;
+                  videoElement.muted = newMuted;
+                }
+              }}
+              aria-label={volume === 0 ? 'ミュート解除' : 'ミュート'}
+            >
+              <Icon 
+                icon={volume === 0 ? ICONS.VOLUME_OFF : ICONS.VOLUME_UP} 
+                size="sm" 
+                color="white" 
+              />
+            </button>
+            <input
+              type="range"
+              min="0"
+              max="1"
+              step="0.1"
+              value={volume}
+              class="w-16 h-1 bg-white/30 rounded-lg appearance-none cursor-pointer slider"
+              oninput={handleVolumeChange}
+              aria-label="音量"
+            />
+          </div>
+          
+          <!-- 時間表示 -->
+          <span class="text-sm tabular-nums">
+            {formatTime(currentTime)} / {formatTime(duration)}
+          </span>
+        </div>
+        
+        <!-- 右側コントロール -->
+        <div class="flex items-center gap-2">
+          <!-- フルスクリーン -->
+          <button
+            class="p-1 hover:bg-white/20 rounded transition-colors"
+            onclick={toggleFullscreen}
+            aria-label={isFullscreen ? 'フルスクリーン解除' : 'フルスクリーン'}
+          >
+            <Icon 
+              icon={isFullscreen ? ICONS.FULLSCREEN_EXIT : ICONS.FULLSCREEN} 
+              size="sm" 
+              color="white" 
+            />
+          </button>
+        </div>
+      </div>
+    </div>
+  {/if}
+
+  <!-- alt テキスト表示（設定で有効な場合） -->
+  {#if displayOptions.showAlt && videoData().alt}
+    <div 
+      class="absolute top-2 left-2 bg-black/60 text-white text-sm px-2 py-1 rounded backdrop-blur-sm max-w-xs"
+      aria-hidden="true"
+    >
+      {videoData().alt}
+    </div>
+  {/if}
+</div>
+
+<!--
+使用例:
+
+基本的な使用:
+<VideoEmbed {embed} />
+
+自動再生・ミュート:
+<VideoEmbed 
+  {embed}
+  autoplay={true}
+  muted={true}
+/>
+
+カスタムオプション:
+<VideoEmbed 
+  {embed}
+  options={{
+    maxWidth: 800,
+    maxHeight: 450,
+    rounded: true,
+    showAlt: true
+  }}
+/>
+-->
+
+<style>
+  /* スライダーのカスタムスタイル */
+  .slider {
+    -webkit-appearance: none;
+    appearance: none;
+  }
+  
+  .slider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: white;
+    cursor: pointer;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  }
+  
+  .slider::-moz-range-thumb {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: white;
+    cursor: pointer;
+    border: none;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  }
+  
+  /* ホバー時のスライダー */
+  .slider:hover::-webkit-slider-thumb {
+    transform: scale(1.2);
+  }
+  
+  .slider:hover::-moz-range-thumb {
+    transform: scale(1.2);
+  }
+  
+  /* フォーカス状態 */
+  .slider:focus {
+    outline: none;
+  }
+  
+  .slider:focus::-webkit-slider-thumb {
+    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.5);
+  }
+  
+  .slider:focus::-moz-range-thumb {
+    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.5);
+  }
+</style>

--- a/moodeSky/src/lib/components/embeddings/VideoEmbed.svelte
+++ b/moodeSky/src/lib/components/embeddings/VideoEmbed.svelte
@@ -178,7 +178,7 @@
 
 <!-- 動画埋め込みコンテナ -->
 <div 
-  class="relative w-full {additionalClass} {getAspectRatioStyle(videoData().aspectRatio)}"
+  class="relative w-full border border-subtle rounded-lg overflow-hidden {additionalClass} {getAspectRatioStyle(videoData().aspectRatio)}"
   style="max-width: {displayOptions.maxWidth}px; max-height: {displayOptions.maxHeight}px;"
   onmouseenter={() => showControls = true}
   onmouseleave={() => showControls = false}

--- a/moodeSky/src/lib/components/embeddings/types.ts
+++ b/moodeSky/src/lib/components/embeddings/types.ts
@@ -1,0 +1,359 @@
+/**
+ * AT Protocol 埋め込みコンテンツの型定義
+ * Bluesky で使用される埋め込みタイプの包括的な型定義システム
+ */
+
+/**
+ * 基本的な埋め込みタイプ識別子
+ */
+export type EmbedType = 'images' | 'video' | 'external' | 'record' | 'recordWithMedia';
+
+/**
+ * アスペクト比定義（画像・動画用）
+ */
+export interface AspectRatio {
+  width: number;
+  height: number;
+}
+
+/**
+ * Blob参照（AT Protocol）
+ * 実際の実装では @atproto/api の BlobRef を使用予定
+ */
+export interface BlobRef {
+  $type: 'blob';
+  ref: {
+    $link: string;
+  };
+  mimeType: string;
+  size: number;
+}
+
+/**
+ * 画像埋め込み（app.bsky.embed.images）
+ */
+export interface ImageEmbed {
+  $type: 'app.bsky.embed.images';
+  images: Array<{
+    image: BlobRef;
+    alt: string;
+    aspectRatio?: AspectRatio;
+  }>;
+}
+
+/**
+ * 動画埋め込み（app.bsky.embed.video）
+ * 最大100MBサイズ制限
+ */
+export interface VideoEmbed {
+  $type: 'app.bsky.embed.video';
+  video: BlobRef;
+  alt?: string;
+  aspectRatio?: AspectRatio;
+  captions?: Array<{
+    lang: string;
+    file: BlobRef;
+  }>;
+}
+
+/**
+ * 外部リンク埋め込み（app.bsky.embed.external）
+ */
+export interface ExternalEmbed {
+  $type: 'app.bsky.embed.external';
+  external: {
+    uri: string;
+    title: string;
+    description: string;
+    thumb?: BlobRef;
+  };
+}
+
+/**
+ * 記録参照（AT URI + CID）
+ */
+export interface RecordRef {
+  uri: string;
+  cid: string;
+}
+
+/**
+ * 記録埋め込み（app.bsky.embed.record）
+ */
+export interface RecordEmbed {
+  $type: 'app.bsky.embed.record';
+  record: RecordRef;
+}
+
+/**
+ * 記録+メディア複合埋め込み（app.bsky.embed.recordWithMedia）
+ */
+export interface RecordWithMediaEmbed {
+  $type: 'app.bsky.embed.recordWithMedia';
+  record: RecordEmbed['record'];
+  media: ImageEmbed | VideoEmbed | ExternalEmbed;
+}
+
+/**
+ * すべての埋め込みタイプのユニオン型
+ */
+export type Embed = ImageEmbed | VideoEmbed | ExternalEmbed | RecordEmbed | RecordWithMediaEmbed;
+
+/**
+ * 埋め込み表示用のView型（API レスポンス）
+ */
+
+/**
+ * 画像埋め込み表示用
+ */
+export interface ImageEmbedView {
+  $type: 'app.bsky.embed.images#view';
+  images: Array<{
+    thumb: string;    // URL
+    fullsize: string; // URL  
+    alt: string;
+    aspectRatio?: AspectRatio;
+  }>;
+}
+
+/**
+ * 動画埋め込み表示用
+ */
+export interface VideoEmbedView {
+  $type: 'app.bsky.embed.video#view';
+  cid: string;
+  playlist: string; // m3u8 URL
+  thumbnail?: string; // URL
+  alt?: string;
+  aspectRatio?: AspectRatio;
+}
+
+/**
+ * 外部リンク埋め込み表示用
+ */
+export interface ExternalEmbedView {
+  $type: 'app.bsky.embed.external#view';
+  external: {
+    uri: string;
+    title: string;
+    description: string;
+    thumb?: string; // URL
+  };
+}
+
+/**
+ * 記録埋め込み表示用
+ */
+export interface RecordEmbedView {
+  $type: 'app.bsky.embed.record#view';
+  record: {
+    uri: string;
+    cid: string;
+    author: {
+      did: string;
+      handle: string;
+      displayName?: string;
+      avatar?: string;
+    };
+    value: any; // 実際の記録データ
+    indexedAt: string;
+    embeds?: EmbedView[];
+  };
+}
+
+/**
+ * 記録+メディア複合埋め込み表示用
+ */
+export interface RecordWithMediaEmbedView {
+  $type: 'app.bsky.embed.recordWithMedia#view';
+  record: RecordEmbedView['record'];
+  media: ImageEmbedView | VideoEmbedView | ExternalEmbedView;
+}
+
+/**
+ * すべての埋め込み表示タイプのユニオン型
+ */
+export type EmbedView = 
+  | ImageEmbedView 
+  | VideoEmbedView 
+  | ExternalEmbedView 
+  | RecordEmbedView 
+  | RecordWithMediaEmbedView;
+
+/**
+ * タイプガード関数群
+ */
+
+export function isImageEmbed(embed: Embed): embed is ImageEmbed {
+  return embed.$type === 'app.bsky.embed.images';
+}
+
+export function isVideoEmbed(embed: Embed): embed is VideoEmbed {
+  return embed.$type === 'app.bsky.embed.video';
+}
+
+export function isExternalEmbed(embed: Embed): embed is ExternalEmbed {
+  return embed.$type === 'app.bsky.embed.external';
+}
+
+export function isRecordEmbed(embed: Embed): embed is RecordEmbed {
+  return embed.$type === 'app.bsky.embed.record';
+}
+
+export function isRecordWithMediaEmbed(embed: Embed): embed is RecordWithMediaEmbed {
+  return embed.$type === 'app.bsky.embed.recordWithMedia';
+}
+
+/**
+ * View タイプ用のタイプガード関数群
+ */
+
+export function isImageEmbedView(embed: EmbedView): embed is ImageEmbedView {
+  return embed.$type === 'app.bsky.embed.images#view';
+}
+
+export function isVideoEmbedView(embed: EmbedView): embed is VideoEmbedView {
+  return embed.$type === 'app.bsky.embed.video#view';
+}
+
+export function isExternalEmbedView(embed: EmbedView): embed is ExternalEmbedView {
+  return embed.$type === 'app.bsky.embed.external#view';
+}
+
+export function isRecordEmbedView(embed: EmbedView): embed is RecordEmbedView {
+  return embed.$type === 'app.bsky.embed.record#view';
+}
+
+export function isRecordWithMediaEmbedView(embed: EmbedView): embed is RecordWithMediaEmbedView {
+  return embed.$type === 'app.bsky.embed.recordWithMedia#view';
+}
+
+/**
+ * 埋め込みタイプ判定ユーティリティ
+ */
+export function getEmbedType(embed: Embed | EmbedView): EmbedType {
+  const type = embed.$type;
+  
+  if (type.includes('images')) return 'images';
+  if (type.includes('video')) return 'video';
+  if (type.includes('external')) return 'external';
+  if (type.includes('recordWithMedia')) return 'recordWithMedia';
+  if (type.includes('record')) return 'record';
+  
+  throw new Error(`Unknown embed type: ${type}`);
+}
+
+/**
+ * 埋め込みコンテンツの妥当性検証
+ */
+export function validateEmbed(embed: unknown): embed is Embed {
+  if (!embed || typeof embed !== 'object') {
+    return false;
+  }
+  
+  const embedObj = embed as any;
+  const validTypes = [
+    'app.bsky.embed.images',
+    'app.bsky.embed.video', 
+    'app.bsky.embed.external',
+    'app.bsky.embed.record',
+    'app.bsky.embed.recordWithMedia'
+  ];
+  
+  return validTypes.includes(embedObj.$type);
+}
+
+/**
+ * 埋め込みコンテンツのメタデータ
+ */
+export interface EmbedMetadata {
+  type: EmbedType;
+  hasMedia: boolean;
+  mediaCount?: number;
+  hasAlt: boolean;
+  aspectRatio?: AspectRatio;
+  size?: number; // bytes
+  duration?: number; // seconds (video)
+}
+
+/**
+ * 埋め込みコンテンツからメタデータを抽出
+ * 注意: 型安全性のため、実行時の型チェックに依存
+ */
+export function extractEmbedMetadata(embed: Embed | EmbedView): EmbedMetadata {
+  const type = getEmbedType(embed);
+  
+  const metadata: EmbedMetadata = {
+    type,
+    hasMedia: false,
+    hasAlt: false
+  };
+  
+  try {
+    // 画像埋め込みの処理
+    if (type === 'images') {
+      const imageEmbed = embed as any;
+      metadata.hasMedia = true;
+      metadata.mediaCount = imageEmbed.images?.length || 0;
+      metadata.hasAlt = imageEmbed.images?.some((img: any) => img.alt && img.alt.trim() !== '') || false;
+      metadata.aspectRatio = imageEmbed.images?.[0]?.aspectRatio;
+    }
+    // 動画埋め込みの処理
+    else if (type === 'video') {
+      const videoEmbed = embed as any;
+      metadata.hasMedia = true;
+      metadata.mediaCount = 1;
+      metadata.hasAlt = !!(videoEmbed.alt && videoEmbed.alt.trim() !== '');
+      metadata.aspectRatio = videoEmbed.aspectRatio;
+    }
+    // 外部リンク埋め込みの処理
+    else if (type === 'external') {
+      const externalEmbed = embed as any;
+      metadata.hasMedia = !!externalEmbed.external?.thumb;
+      metadata.mediaCount = metadata.hasMedia ? 1 : 0;
+    }
+    // RecordWithMedia埋め込みの処理
+    else if (type === 'recordWithMedia') {
+      const recordWithMediaEmbed = embed as any;
+      if (recordWithMediaEmbed.media) {
+        const mediaMetadata = extractEmbedMetadata(recordWithMediaEmbed.media);
+        metadata.hasMedia = mediaMetadata.hasMedia;
+        metadata.mediaCount = mediaMetadata.mediaCount;
+        metadata.hasAlt = mediaMetadata.hasAlt;
+        metadata.aspectRatio = mediaMetadata.aspectRatio;
+      }
+    }
+  } catch (error) {
+    console.warn('Error extracting embed metadata:', error);
+  }
+  
+  return metadata;
+}
+
+/**
+ * 埋め込みコンテンツの表示設定
+ */
+export interface EmbedDisplayOptions {
+  maxWidth?: number;
+  maxHeight?: number;
+  showAlt?: boolean;
+  lazy?: boolean;
+  rounded?: boolean;
+  shadow?: boolean;
+  interactive?: boolean;
+  clickable?: boolean;
+}
+
+/**
+ * デフォルト表示設定
+ */
+export const DEFAULT_EMBED_DISPLAY_OPTIONS: EmbedDisplayOptions = {
+  maxWidth: 600,
+  maxHeight: 400,
+  showAlt: true,
+  lazy: true,
+  rounded: true,
+  shadow: false,
+  interactive: true,
+  clickable: true
+};

--- a/moodeSky/src/lib/services/embedService.ts
+++ b/moodeSky/src/lib/services/embedService.ts
@@ -1,0 +1,384 @@
+/**
+ * AT Protocol 埋め込みコンテンツ処理サービス
+ * BlobRef から CDN URL への変換とユーティリティ関数
+ */
+
+import type { BlobRef, Embed, EmbedView } from '$lib/components/embeddings/types.js';
+
+/**
+ * AT Protocol の公式 CDN エンドポイント
+ */
+const CDN_BASE_URL = 'https://cdn.bsky.app';
+
+/**
+ * BlobRef から画像 CDN URL を生成
+ */
+export function generateImageUrls(blobRef: BlobRef | string): { thumbnail: string; fullsize: string } {
+  console.log('🔄 [EmbedService] generateImageUrls called with:', {
+    type: typeof blobRef,
+    isString: typeof blobRef === 'string',
+    blobRef: blobRef
+  });
+
+  if (typeof blobRef === 'string') {
+    // 既に URL の場合はそのまま返す
+    console.log('✅ [EmbedService] Using existing URL:', blobRef);
+    return {
+      thumbnail: blobRef,
+      fullsize: blobRef
+    };
+  }
+
+  if (!blobRef || typeof blobRef !== 'object') {
+    console.warn('🚫 [EmbedService] Invalid BlobRef - not an object:', blobRef);
+    return {
+      thumbnail: '',
+      fullsize: ''
+    };
+  }
+
+  if (!blobRef.ref || typeof blobRef.ref !== 'object') {
+    console.warn('🚫 [EmbedService] Invalid BlobRef - missing ref:', blobRef);
+    return {
+      thumbnail: '',
+      fullsize: ''
+    };
+  }
+
+  if (!blobRef.ref.$link || typeof blobRef.ref.$link !== 'string') {
+    console.warn('🚫 [EmbedService] Invalid BlobRef - missing $link:', blobRef);
+    return {
+      thumbnail: '',
+      fullsize: ''
+    };
+  }
+
+  const hash = blobRef.ref.$link;
+  
+  const result = {
+    thumbnail: `${CDN_BASE_URL}/img/feed_thumbnail/plain/${hash}`,
+    fullsize: `${CDN_BASE_URL}/img/feed_fullsize/plain/${hash}`
+  };
+
+  console.log('✅ [EmbedService] Generated CDN URLs:', {
+    hash,
+    thumbnail: result.thumbnail,
+    fullsize: result.fullsize
+  });
+  
+  return result;
+}
+
+/**
+ * BlobRef から動画 CDN URL を生成
+ */
+export function generateVideoUrls(blobRef: BlobRef | string): { playlist: string; thumbnail?: string } {
+  console.log('🔄 [EmbedService] generateVideoUrls called with:', {
+    type: typeof blobRef,
+    isString: typeof blobRef === 'string',
+    blobRef: blobRef
+  });
+
+  if (typeof blobRef === 'string') {
+    // 既に URL の場合はそのまま返す
+    console.log('✅ [EmbedService] Using existing video URL:', blobRef);
+    return {
+      playlist: blobRef
+    };
+  }
+
+  if (!blobRef || typeof blobRef !== 'object') {
+    console.warn('🚫 [EmbedService] Invalid video BlobRef - not an object:', blobRef);
+    return {
+      playlist: ''
+    };
+  }
+
+  if (!blobRef.ref || typeof blobRef.ref !== 'object') {
+    console.warn('🚫 [EmbedService] Invalid video BlobRef - missing ref:', blobRef);
+    return {
+      playlist: ''
+    };
+  }
+
+  if (!blobRef.ref.$link || typeof blobRef.ref.$link !== 'string') {
+    console.warn('🚫 [EmbedService] Invalid video BlobRef - missing $link:', blobRef);
+    return {
+      playlist: ''
+    };
+  }
+
+  const hash = blobRef.ref.$link;
+  
+  const result = {
+    playlist: `${CDN_BASE_URL}/vid/feed_fullsize/plain/${hash}/playlist.m3u8`,
+    thumbnail: `${CDN_BASE_URL}/img/feed_thumbnail/plain/${hash}`
+  };
+
+  console.log('✅ [EmbedService] Generated video CDN URLs:', {
+    hash,
+    playlist: result.playlist,
+    thumbnail: result.thumbnail
+  });
+  
+  return result;
+}
+
+/**
+ * 外部リンクのサムネイル URL を生成
+ */
+export function generateExternalThumbnailUrl(blobRef: BlobRef | string): string {
+  if (typeof blobRef === 'string') {
+    return blobRef;
+  }
+
+  if (!blobRef || typeof blobRef !== 'object' || !blobRef.ref || !blobRef.ref.$link) {
+    console.warn('🚫 [EmbedService] Invalid external thumbnail BlobRef:', blobRef);
+    return '';
+  }
+
+  return `${CDN_BASE_URL}/img/feed_thumbnail/plain/${blobRef.ref.$link}`;
+}
+
+/**
+ * Embed オブジェクトを EmbedView 形式に正規化
+ * BlobRef を適切な CDN URL に変換
+ */
+export function normalizeEmbedToView(embed: Embed | EmbedView): EmbedView | null {
+  try {
+    console.log('🔄 [EmbedService] Normalizing embed:', {
+      type: embed.$type,
+      hasViewSuffix: embed.$type.includes('#view')
+    });
+
+    // 既に View 形式の場合はそのまま返す
+    if (embed.$type.includes('#view')) {
+      console.log('✅ [EmbedService] Already a view object, returning as-is');
+      return embed as EmbedView;
+    }
+
+    // Raw Embed を EmbedView に変換
+    switch (embed.$type) {
+      case 'app.bsky.embed.images': {
+        const imageEmbed = embed as any;
+        const normalizedImages = imageEmbed.images?.map((img: any, index: number) => {
+          const { thumbnail, fullsize } = generateImageUrls(img.image);
+          
+          console.log(`🖼️ [EmbedService] Image ${index} normalization:`, {
+            originalHasImage: !!img.image,
+            originalImageType: typeof img.image,
+            generatedThumbnail: thumbnail,
+            generatedFullsize: fullsize,
+            hasValidUrls: !!(thumbnail && fullsize)
+          });
+          
+          return {
+            thumb: thumbnail,
+            fullsize: fullsize,
+            alt: img.alt || '',
+            aspectRatio: img.aspectRatio
+          };
+        }) || [];
+
+        const result = {
+          $type: 'app.bsky.embed.images#view' as const,
+          images: normalizedImages
+        };
+
+        console.log('🖼️ [EmbedService] Images embed normalized:', {
+          originalCount: imageEmbed.images?.length || 0,
+          normalizedCount: normalizedImages.length,
+          validUrls: normalizedImages.filter((img: any) => img.thumb && img.fullsize).length
+        });
+
+        return result;
+      }
+
+      case 'app.bsky.embed.video': {
+        const videoEmbed = embed as any;
+        const { playlist, thumbnail } = generateVideoUrls(videoEmbed.video);
+        
+        console.log('🎥 [EmbedService] Video normalization:', {
+          originalHasVideo: !!videoEmbed.video,
+          originalVideoType: typeof videoEmbed.video,
+          generatedPlaylist: playlist,
+          generatedThumbnail: thumbnail,
+          hasValidPlaylist: !!playlist
+        });
+
+        const result = {
+          $type: 'app.bsky.embed.video#view' as const,
+          cid: videoEmbed.cid || '',
+          playlist: playlist,
+          thumbnail: thumbnail,
+          alt: videoEmbed.alt,
+          aspectRatio: videoEmbed.aspectRatio
+        };
+
+        return result;
+      }
+
+      case 'app.bsky.embed.external': {
+        const externalEmbed = embed as any;
+        const external = externalEmbed.external;
+        
+        const result = {
+          $type: 'app.bsky.embed.external#view' as const,
+          external: {
+            uri: external.uri,
+            title: external.title,
+            description: external.description,
+            thumb: external.thumb ? generateExternalThumbnailUrl(external.thumb) : undefined
+          }
+        };
+
+        console.log('🔗 [EmbedService] External link normalized:', {
+          uri: external.uri,
+          hasThumb: !!external.thumb,
+          generatedThumb: result.external.thumb
+        });
+
+        return result;
+      }
+
+      case 'app.bsky.embed.record': {
+        // Record embeds は基本的にそのまま View 形式として扱う
+        const result = {
+          ...embed,
+          $type: 'app.bsky.embed.record#view' as const
+        };
+
+        console.log('📝 [EmbedService] Record embed normalized');
+        return result as EmbedView;
+      }
+
+      case 'app.bsky.embed.recordWithMedia': {
+        const recordWithMediaEmbed = embed as any;
+        
+        // メディア部分を再帰的に正規化
+        const normalizedMedia = recordWithMediaEmbed.media 
+          ? normalizeEmbedToView(recordWithMediaEmbed.media)
+          : null;
+
+        if (!normalizedMedia) {
+            return null;
+        }
+
+        const result = {
+          $type: 'app.bsky.embed.recordWithMedia#view' as const,
+          record: recordWithMediaEmbed.record,
+          media: normalizedMedia
+        };
+
+        return result as EmbedView;
+      }
+
+      default:
+        return null;
+    }
+  } catch (error) {
+    return null;
+  }
+}
+
+/**
+ * 複数の埋め込みを一括で正規化
+ */
+export function normalizeEmbeds(embeds: (Embed | EmbedView)[]): EmbedView[] {
+  if (!Array.isArray(embeds)) {
+    return [];
+  }
+
+  return embeds
+    .map((embed) => normalizeEmbedToView(embed))
+    .filter((embed): embed is EmbedView => embed !== null);
+}
+
+/**
+ * Embed が有効な BlobRef 構造を持っているかチェック
+ */
+export function hasValidBlobRef(blobRef: unknown): blobRef is BlobRef {
+  return !!(
+    blobRef && 
+    typeof blobRef === 'object' && 
+    'ref' in blobRef && 
+    blobRef.ref && 
+    typeof blobRef.ref === 'object' &&
+    '$link' in blobRef.ref &&
+    typeof blobRef.ref.$link === 'string' &&
+    blobRef.ref.$link.length > 0
+  );
+}
+
+/**
+ * デバッグ用: Embed の構造を分析
+ */
+export function analyzeEmbedStructure(embed: unknown): {
+  isValid: boolean;
+  type: string;
+  hasBlobs: boolean;
+  blobCount: number;
+  issues: string[];
+} {
+  const analysis = {
+    isValid: false,
+    type: 'unknown',
+    hasBlobs: false,
+    blobCount: 0,
+    issues: [] as string[]
+  };
+
+  if (!embed || typeof embed !== 'object') {
+    analysis.issues.push('Not an object');
+    return analysis;
+  }
+
+  const embedObj = embed as any;
+  
+  if (!embedObj.$type || typeof embedObj.$type !== 'string') {
+    analysis.issues.push('Missing or invalid $type');
+    return analysis;
+  }
+
+  analysis.type = embedObj.$type;
+
+  // タイプ別の分析
+  switch (embedObj.$type) {
+    case 'app.bsky.embed.images':
+    case 'app.bsky.embed.images#view':
+      if (!embedObj.images || !Array.isArray(embedObj.images)) {
+        analysis.issues.push('Missing or invalid images array');
+      } else {
+        analysis.blobCount = embedObj.images.length;
+        analysis.hasBlobs = embedObj.images.some((img: any) => 
+          img.image ? hasValidBlobRef(img.image) : !!img.thumb
+        );
+        analysis.isValid = analysis.hasBlobs;
+      }
+      break;
+
+    case 'app.bsky.embed.video':
+    case 'app.bsky.embed.video#view':
+      if (embedObj.$type.includes('#view')) {
+        analysis.hasBlobs = !!embedObj.playlist;
+        analysis.blobCount = analysis.hasBlobs ? 1 : 0;
+      } else {
+        analysis.hasBlobs = hasValidBlobRef(embedObj.video);
+        analysis.blobCount = analysis.hasBlobs ? 1 : 0;
+      }
+      analysis.isValid = analysis.hasBlobs;
+      break;
+
+    case 'app.bsky.embed.external':
+    case 'app.bsky.embed.external#view':
+      analysis.isValid = !!(embedObj.external && embedObj.external.uri);
+      analysis.hasBlobs = !!(embedObj.external?.thumb);
+      analysis.blobCount = analysis.hasBlobs ? 1 : 0;
+      break;
+
+    default:
+      analysis.issues.push(`Unsupported embed type: ${embedObj.$type}`);
+  }
+
+  return analysis;
+}

--- a/moodeSky/src/lib/types/icon.ts
+++ b/moodeSky/src/lib/types/icon.ts
@@ -136,6 +136,23 @@ export const ICONS = {
   // 音量・アクティビティ
   VOLUME_DOWN: 'material-symbols:volume-down',
   VOLUME_UP: 'material-symbols:volume-up',
+  VOLUME_OFF: 'material-symbols:volume-off',
+  
+  // メディアコントロール
+  PLAY_ARROW: 'material-symbols:play-arrow',
+  PAUSE: 'material-symbols:pause',
+  STOP: 'material-symbols:stop',
+  SKIP_NEXT: 'material-symbols:skip-next',
+  SKIP_PREVIOUS: 'material-symbols:skip-previous',
+  FAST_FORWARD: 'material-symbols:fast-forward',
+  FAST_REWIND: 'material-symbols:fast-rewind',
+  REPLAY: 'material-symbols:replay',
+  
+  // 画面・表示
+  FULLSCREEN: 'material-symbols:fullscreen',
+  FULLSCREEN_EXIT: 'material-symbols:fullscreen-exit',
+  ZOOM_IN: 'material-symbols:zoom-in',
+  ZOOM_OUT: 'material-symbols:zoom-out',
   
   // デッキ・カラム管理
   DASHBOARD: 'material-symbols:dashboard',
@@ -170,6 +187,11 @@ export const ICONS = {
   ATTACH_FILE: 'material-symbols:attach-file',
   DOWNLOAD: 'material-symbols:download',
   UPLOAD: 'material-symbols:upload',
+  
+  // リンク・ナビゲーション
+  OPEN_IN_NEW: 'material-symbols:open-in-new',
+  LINK: 'material-symbols:link',
+  LINK_OFF: 'material-symbols:link-off',
   
   // 設定・スケジュール
   SCHEDULE: 'material-symbols:schedule',

--- a/moodeSky/src/lib/types/post.ts
+++ b/moodeSky/src/lib/types/post.ts
@@ -1,7 +1,10 @@
 /**
  * シンプルなPost型定義
  * 段階的実装: 基本表示に必要な最小限のフィールドのみ
+ * 埋め込みコンテンツ（images, video, external, record）対応
  */
+
+import type { Embed, EmbedView } from '$lib/components/embeddings/types.js';
 
 /**
  * 投稿作者の基本情報
@@ -27,6 +30,10 @@ export interface SimplePost {
   // 投稿内容
   text: string;
   createdAt: string;
+  
+  // 埋め込みコンテンツ
+  embed?: Embed | EmbedView;
+  embeds?: (Embed | EmbedView)[];
   
   // 基本統計
   replyCount?: number;


### PR DESCRIPTION
## Summary
- 画像埋め込み（ImageEmbed）の16:9グリッドコンテナに枠線と角丸を追加
- 動画埋め込み（VideoEmbed）のコンテナに枠線と角丸を追加
- `border-subtle rounded-lg overflow-hidden`クラスでテーマシステムに準拠
- 外部リンク・引用投稿は既に実装済みのため変更なし

## 変更内容
- **ImageEmbed.svelte**: 16:9グリッドコンテナに `border border-subtle rounded-lg overflow-hidden` を追加
- **VideoEmbed.svelte**: 動画コンテナに `border border-subtle rounded-lg overflow-hidden` を追加

## Test plan
- [ ] 画像埋め込み: 枠線表示確認（Sky/Sunset/High Contrast各テーマ）
- [ ] 動画埋め込み: 枠線表示確認（Sky/Sunset/High Contrast各テーマ）
- [ ] 角丸: overflow-hiddenによる適切なクリッピング確認
- [ ] アクセシビリティ: フォーカス状態での境界線表示確認
- [ ] 外部リンク・引用投稿: 既存枠線が維持されていることを確認
- [ ] レスポンシブ: 異なる画面サイズでの枠線表示確認

🤖 Generated with [Claude Code](https://claude.ai/code)