### PR TITLE
feat: Improve image embed border styling - Better visual separation

### DIFF
--- a/moodeSky/src/lib/components/embeddings/ImageEmbed.svelte
+++ b/moodeSky/src/lib/components/embeddings/ImageEmbed.svelte
@@ -101,7 +101,7 @@
 
   // 個別画像のスタイルクラス（16:9レイアウト対応）
   const getImageClass = (index: number, totalCount: number) => {
-    let baseClass = 'relative overflow-hidden transition-all duration-200 bg-muted';
+    let baseClass = 'relative overflow-hidden transition-all duration-200 bg-muted border border-subtle';
     
     // 角丸設定
     if (displayOptions.rounded) {
@@ -197,7 +197,7 @@
   style="max-width: {displayOptions.maxWidth}px;"
 >
   <!-- 16:9美しい画像グリッド -->
-  <div class="relative w-full aspect-[16/9] border-subtle rounded-lg overflow-hidden {gridLayoutClass()}">
+  <div class="relative w-full aspect-[16/9] rounded-lg overflow-hidden {gridLayoutClass()}">
     {#each images().slice(0, maxImages) as image, index}
       <!-- 個別画像コンテナ -->
       {#if displayOptions.clickable}


### PR DESCRIPTION
## Summary

画像埋め込みのボーダー表示を改善し、視覚的な分離を向上させました。

## 🔧 Changes

- **外側コンテナのボーダーを削除**: 画像グループ全体を囲むボーダーを削除
- **個別画像にボーダーを追加**: 各画像要素に `border border-subtle` を適用  
- **レイアウト保持**: 16:9アスペクト比グリッドレイアウトと角丸は維持

## 🎯 Visual Impact

**変更前:**
- 画像グループ全体を囲む1つのボーダー
- 複数画像でも外枠のみ

**変更後:**  
- 各画像が個別にボーダーで縁取られる
- 複数画像時の視覚的分離が明確に

## 📁 Modified Files

- `src/lib/components/embeddings/ImageEmbed.svelte`
  - 200行目: 外側コンテナの `border-subtle` 削除
  - 104行目: `getImageClass` 関数で個別ボーダー追加

## Test plan

- [x] TypeScript/Svelte型チェック通過確認
- [x] 1枚〜4枚画像レイアウトでの表示確認  
- [x] 角丸とホバー効果の保持確認
- [x] レスポンシブデザインの維持確認

🤖 Generated with [Claude Code](https://claude.ai/code)