### PR TITLE
feat: Add multilingual repost badge component

### DIFF
--- a/moodeSky/src/lib/components/PostCard.svelte
+++ b/moodeSky/src/lib/components/PostCard.svelte
@@ -6,6 +6,7 @@
 <script lang="ts">
   import Avatar from './Avatar.svelte';
   import PostActionButton from './post/PostActionButton.svelte';
+  import RepostBadge from './post/RepostBadge.svelte';
   import EmbedRenderer from './embeddings/EmbedRenderer.svelte';
   import { formatRelativeTime, formatAbsoluteTime } from '$lib/utils/relativeTime.js';
   import { ICONS } from '$lib/types/icon.js';
@@ -122,13 +123,22 @@
     console.warn('Embed rendering error:', error, embed);
     // TODO: エラー報告システム実装
   }
+
+  // リポストユーザークリックハンドラー
+  function handleRepostUserClick(did: string, handle: string) {
+    console.log('Navigate to repost user profile:', did, handle);
+    // TODO: プロフィールページへのナビゲーション実装
+  }
 </script>
 
-<!-- ポストカード -->
 <article class="bg-card border-b border-subtle p-4 hover:bg-muted/5 transition-colors {className}">
-  <!-- ヘッダー: アバター + 作者情報 + 日時 -->
+  <RepostBadge 
+    reason={post.reason}
+    onClick={handleRepostUserClick}
+    class="mb-2"
+  />
+  
   <header class="flex items-start gap-3 mb-3">
-    <!-- アバター -->
     <Avatar 
       src={post.author.avatar}
       displayName={post.author.displayName}
@@ -136,10 +146,7 @@
       size="sm"
       class="mt-1"
     />
-    
-    <!-- 作者情報と日時 -->
     <div class="flex-1 min-w-0">
-      <!-- 1行目: 表示名と日時 (displayNameが有効な場合のみ) -->
       {#if hasValidDisplayName}
         <div class="flex items-center justify-between gap-2">
           <h3 class="font-semibold text-themed text-sm truncate">

--- a/moodeSky/src/lib/components/post/RepostBadge.svelte
+++ b/moodeSky/src/lib/components/post/RepostBadge.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+  import Icon from '../Icon.svelte';
+  import { ICONS } from '$lib/types/icon.js';
+  import type { RepostReason } from '$lib/types/post.js';
+  import * as m from '../../../paraglide/messages.js';
+
+  interface Props {
+    /** リポスト情報（undefinedの場合は表示しない） */
+    reason?: RepostReason;
+    /** 追加CSSクラス */
+    class?: string;
+    /** ユーザークリック時の処理 */
+    onClick?: (did: string, handle: string) => void;
+  }
+
+  const { 
+    reason, 
+    class: additionalClass = '',
+    onClick
+  }: Props = $props();
+
+  // 表示名の決定（displayName → handle の優先順位）
+  const displayName = $derived(() => {
+    if (!reason?.by) return '';
+    return reason.by.displayName && reason.by.displayName.trim() !== '' 
+      ? reason.by.displayName 
+      : reason.by.handle;
+  });
+
+  // ユーザークリックハンドラー
+  function handleUserClick() {
+    if (onClick && reason?.by) {
+      onClick(reason.by.did, reason.by.handle);
+    }
+  }
+</script>
+
+{#if reason && reason.by}
+  <div class="flex items-center gap-2 py-1 text-secondary text-sm {additionalClass}">
+    <Icon 
+      icon={ICONS.REPEAT} 
+      size="sm" 
+      color="secondary" 
+      ariaLabel="リポスト"
+      decorative={false}
+    />
+    
+    <span class="flex items-center gap-1">
+      {#if onClick}
+        <button 
+          class="font-medium hover:underline focus:outline-none focus:underline transition-all duration-150"
+          onclick={handleUserClick}
+          aria-label="プロフィールを表示: {displayName()}"
+        >
+          {displayName()}
+        </button>
+      {:else}
+        <span class="font-medium">
+          {displayName()}
+        </span>
+      {/if}
+      
+      <span>{m.reposted()}</span>
+    </span>
+  </div>
+{/if}
+
+<style>
+  /* ホバー効果の微調整 */
+  button:hover {
+    text-decoration-thickness: 1px;
+    text-underline-offset: 2px;
+  }
+  
+  /* フォーカス状態の視覚化 */
+  button:focus {
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 2px;
+  }
+</style>

--- a/moodeSky/src/lib/deck/components/DeckColumn.svelte
+++ b/moodeSky/src/lib/deck/components/DeckColumn.svelte
@@ -348,7 +348,18 @@
             replyCount: post.replyCount,
             repostCount: post.repostCount,
             likeCount: post.likeCount,
-            indexedAt: post.indexedAt
+            indexedAt: post.indexedAt,
+            // リポスト情報のマッピング
+            reason: item.reason ? {
+              $type: item.reason.$type,
+              by: {
+                did: item.reason.by.did,
+                handle: item.reason.by.handle,
+                displayName: item.reason.by.displayName,
+                avatar: item.reason.by.avatar
+              },
+              indexedAt: item.reason.indexedAt
+            } : undefined
           };
         });
         

--- a/moodeSky/src/lib/i18n/locales/de.json
+++ b/moodeSky/src/lib/i18n/locales/de.json
@@ -5,6 +5,7 @@
     "loading": "Wird geladen...",
     "error": "Ein Fehler ist aufgetreten"
   },
+  "reposted": " hat repostet",
   "navigation": {
     "home": "Startseite",
     "deck": "Deck",

--- a/moodeSky/src/lib/i18n/locales/en.json
+++ b/moodeSky/src/lib/i18n/locales/en.json
@@ -5,6 +5,7 @@
     "loading": "Loading...",
     "error": "An error occurred"
   },
+  "reposted": " reposted",
   "navigation": {
     "home": "Home",
     "deck": "Deck",

--- a/moodeSky/src/lib/i18n/locales/ja.json
+++ b/moodeSky/src/lib/i18n/locales/ja.json
@@ -5,6 +5,7 @@
     "loading": "読み込み中...",
     "error": "エラーが発生しました"
   },
+  "reposted": "がリポスト",
   "navigation": {
     "home": "ホーム",
     "deck": "デッキ",

--- a/moodeSky/src/lib/i18n/locales/ko.json
+++ b/moodeSky/src/lib/i18n/locales/ko.json
@@ -5,6 +5,7 @@
     "loading": "로딩 중...",
     "error": "오류가 발생했습니다"
   },
+  "reposted": " 리포스트함",
   "navigation": {
     "home": "홈",
     "deck": "덱",

--- a/moodeSky/src/lib/i18n/locales/pt-BR.json
+++ b/moodeSky/src/lib/i18n/locales/pt-BR.json
@@ -5,6 +5,7 @@
     "loading": "Carregando...",
     "error": "Ocorreu um erro"
   },
+  "reposted": " repostou",
   "navigation": {
     "home": "Início",
     "deck": "Painel",

--- a/moodeSky/src/lib/types/post.ts
+++ b/moodeSky/src/lib/types/post.ts
@@ -17,6 +17,16 @@ export interface PostAuthor {
 }
 
 /**
+ * リポスト理由情報
+ * AT Protocol app.bsky.feed.defs#reasonRepost準拠
+ */
+export interface RepostReason {
+  $type: 'app.bsky.feed.defs#reasonRepost';
+  by: PostAuthor;
+  indexedAt: string;
+}
+
+/**
  * 投稿の基本情報
  */
 export interface SimplePost {
@@ -39,6 +49,9 @@ export interface SimplePost {
   replyCount?: number;
   repostCount?: number;
   likeCount?: number;
+  
+  // リポスト情報（リポストされた投稿の場合のみ）
+  reason?: RepostReason;
   
   // インデックス日時
   indexedAt: string;


### PR DESCRIPTION
## Summary
- ✅ RepostBadgeコンポーネント作成（Material Symbols REPEATアイコン使用）
- ✅ 5言語対応（日本語、英語、ポルトガル語、ドイツ語、韓国語）  
- ✅ reasonRepostが存在する場合のみポスト上部に表示

## Technical Implementation
### New Component: RepostBadge.svelte
- **Props**: `reason?: RepostReason`, onClick handler, CSS classes
- **Styling**: Minimal padding (`py-1`), `text-secondary` color  
- **Logic**: Display condition moved inside component for cleaner integration
- **Accessibility**: Proper ARIA labels and focus management

### Data Integration
- **DeckColumn.svelte**: Added reason field mapping from AT Protocol data
- **PostCard.svelte**: Clean integration with minimal props passing
- **Type Safety**: RepostReason interface matching AT Protocol specs

### Internationalization
| Language | Translation |
|----------|-------------|
| 🇯🇵 Japanese | "がリポスト" |
| 🇺🇸 English | " reposted" |
| 🇧🇷 Portuguese | " repostou" |
| 🇩🇪 German | " hat repostet" |
| 🇰🇷 Korean | " 리포스트함" |

## Test Plan
- [x] TypeScript type checking passed (`pnpm run check`)
- [x] Paraglide message compilation successful
- [x] Component renders conditionally based on reason field
- [x] Multi-language switching works correctly
- [x] No layout disruption to existing post cards

## UI/UX Improvements
- Clean Bluesky-style repost indication
- Consistent with platform design patterns
- Minimal visual impact while providing clear information
- Responsive design for mobile and desktop

🤖 Generated with [Claude Code](https://claude.ai/code)