### PR TITLE
feat: Embedding system improvements and repost badge implementation

### DIFF
--- a/moodeSky/src/lib/components/embeddings/EmbedRenderer.svelte
+++ b/moodeSky/src/lib/components/embeddings/EmbedRenderer.svelte
@@ -103,46 +103,27 @@
   const validEmbeds = $derived(() => {
     const normalized = normalizedEmbeds();
     
-    if (debug) {
-      console.log('🔍 [EmbedRenderer] Starting validation:', {
-        embeds: embeds,
-        embedsType: Array.isArray(embeds) ? `Array(${embeds.length})` : typeof embeds,
-        normalized: normalized,
-        normalizedCount: normalized.length
-      });
-    }
     
     return normalized.filter((embed, index) => {
       try {
         if (!embed || typeof embed !== 'object') {
-          if (debug) console.warn(`🚫 [EmbedRenderer] Embed ${index} is not a valid object:`, { embed, type: typeof embed });
           return false;
         }
         
         // より緩和された基本的な検証
         if (!(embed as any).$type || typeof (embed as any).$type !== 'string') {
-          if (debug) console.warn(`🚫 [EmbedRenderer] Embed ${index} missing $type:`, { embed, hasType: !!(embed as any).$type, type: (embed as any).$type });
           return false;
         }
         
         // 基本的なAT Protocol埋め込みタイプかどうかチェック
         const isValidType = (embed as any).$type.startsWith('app.bsky.embed.');
         if (!isValidType) {
-          if (debug) console.warn(`🚫 [EmbedRenderer] Embed ${index} invalid $type:`, { embed, type: (embed as any).$type });
           return false;
         }
         
-        if (debug) {
-          console.log(`✅ [EmbedRenderer] Embed ${index} passed validation:`, { 
-            type: (embed as any).$type, 
-            hasValidStructure: !!embed,
-            embedKeys: Object.keys(embed)
-          });
-        }
         
         return true;
       } catch (error) {
-        if (debug) console.error(`❌ [EmbedRenderer] Error validating embed ${index}:`, { error, embed });
         if (onError) {
           onError(error as Error, embed);
         }
@@ -156,15 +137,9 @@
     try {
       const embedType = getEmbedType(embed);
       
-      if (debug) {
-        console.log(`Rendering embed ${index} of type: ${embedType}`, embed);
-      }
       
       return { type: embedType, embed, error: null };
     } catch (error) {
-      if (debug) {
-        console.error(`Error processing embed ${index}:`, error, embed);
-      }
       if (onError) {
         onError(error as Error, embed);
       }
@@ -223,16 +198,6 @@
 <!-- 埋め込みレンダラーコンテナ -->
 {#if validEmbeds().length > 0}
   <div class="w-full {additionalClass}">
-    <!-- デバッグ情報 -->
-    {#if debug && embedStats()}
-      <div class="mb-2 p-2 bg-muted/10 rounded text-xs text-secondary">
-        <strong>Embed Debug:</strong>
-        Total: {embedStats()?.total}, Valid: {embedStats()?.valid}
-        {#if embedStats()?.types && Object.keys(embedStats()?.types || {}).length > 0}
-          | Types: {Object.entries(embedStats()?.types || {}).map(([type, count]) => `${type}(${count})`).join(', ')}
-        {/if}
-      </div>
-    {/if}
 
     <!-- 埋め込みコンテンツ -->
     <div class="space-y-3">

--- a/moodeSky/src/lib/components/embeddings/ExternalLinkEmbed.svelte
+++ b/moodeSky/src/lib/components/embeddings/ExternalLinkEmbed.svelte
@@ -40,7 +40,7 @@
 
   // 外部リンクデータの正規化（embed vs embedView の違いを吸収）
   const linkData = $derived(() => {
-    const result = {
+    return {
       uri: embed.external.uri,
       title: embed.external.title || 'Untitled',
       description: embed.external.description || '',
@@ -48,15 +48,6 @@
         ? (typeof embed.external.thumb === 'string' ? embed.external.thumb : '#')
         : undefined
     };
-    
-    console.log('🔗 [ExternalLinkEmbed] Link data parsed:', {
-      hasThumb: !!result.thumb,
-      thumbUrl: result.thumb,
-      title: result.title,
-      description: result.description?.slice(0, 50) + '...'
-    });
-    
-    return result;
   });
 
   // ドメイン名を抽出
@@ -96,33 +87,14 @@
 
   // 画像読み込み完了ハンドラー
   const handleImageLoad = (event: Event) => {
-    console.log('🖼️ [ExternalLinkEmbed] Image loaded successfully:', {
-      url: linkData().thumb,
-      imageLoaded: imageLoaded,
-      imageError: imageError
-    });
     imageLoaded = true;
     imageError = false;
-    console.log('🖼️ [ExternalLinkEmbed] State after load:', {
-      imageLoaded: imageLoaded,
-      imageError: imageError
-    });
   };
 
   // 画像読み込みエラーハンドラー
   const handleImageError = (event: Event) => {
-    console.log('🚫 [ExternalLinkEmbed] Image load error:', {
-      url: linkData().thumb,
-      error: event,
-      imageLoaded: imageLoaded,
-      imageError: imageError
-    });
     imageLoaded = false;
     imageError = true;
-    console.log('🚫 [ExternalLinkEmbed] State after error:', {
-      imageLoaded: imageLoaded,
-      imageError: imageError
-    });
   };
 
   // タイトルとディスクリプションの切り詰め

--- a/moodeSky/src/lib/components/embeddings/RecordWithMediaEmbed.svelte
+++ b/moodeSky/src/lib/components/embeddings/RecordWithMediaEmbed.svelte
@@ -63,13 +63,8 @@
   // 表示設定のマージ
   const displayOptions = $derived({ ...DEFAULT_EMBED_DISPLAY_OPTIONS, ...options });
 
-  // 記録データの抽出
-  const recordData = $derived(() => ({
-    uri: embed.record.uri,
-    cid: embed.record.cid,
-    // RecordWithMediaEmbedView の場合は追加データが含まれる
-    ...('author' in embed.record ? embed.record : {})
-  }));
+  // 記録データの抽出（RecordEmbedに委譲）
+  const recordData = $derived(() => embed.record);
 
   // メディアデータの抽出と型判定
   const mediaData = $derived(() => {
@@ -157,6 +152,18 @@
   };
 </script>
 
+<!-- RecordEmbed表示用の共通スニペット -->
+{#snippet recordContent()}
+  <RecordEmbed 
+    embed={{ $type: 'app.bsky.embed.record', record: recordData() }}
+    options={recordOptions()}
+    {onPostClick}
+    {onAuthorClick}
+    maxDepth={2}
+    currentDepth={1}
+  />
+{/snippet}
+
 <!-- 記録+メディア埋め込みコンテナ -->
 <div 
   class={containerClass()}
@@ -194,12 +201,7 @@
     
     <!-- 記録部分 -->
     <div class={recordClass()}>
-      <RecordEmbed 
-        embed={{ $type: 'app.bsky.embed.record', record: recordData() }}
-        options={recordOptions()}
-        {onPostClick}
-        {onAuthorClick}
-      />
+      {@render recordContent()}
     </div>
     
   {:else}
@@ -207,12 +209,7 @@
     
     <!-- 記録部分 -->
     <div class={recordClass()}>
-      <RecordEmbed 
-        embed={{ $type: 'app.bsky.embed.record', record: recordData() }}
-        options={recordOptions()}
-        {onPostClick}
-        {onAuthorClick}
-      />
+      {@render recordContent()}
     </div>
     
     <!-- メディア部分 -->


### PR DESCRIPTION
## Summary
- 多言語対応リポストバッジコンポーネントの実装
- 埋め込みシステムのデバッグログ削除とクリーンアップ
- RecordWithMediaEmbedコンポーネントの重複コード解消

## Key Features
### 🏷️ Multilingual Repost Badge Component
- Material Symbols REPEATアイコンを使用したリポストバッジ
- 5言語対応（日本語、英語、ポルトガル語、ドイツ語、韓国語）
- 条件付き表示（reasonRepost存在時のみ）
- PostCardへの適切な統合

### 🧹 Debug Cleanup
- ExternalLinkEmbedから6個のconsole.logを削除
- EmbedRendererから9個のデバッグ表示を削除
- 重要なエラーハンドリングは保持

### ♻️ Component Reusability
- RecordWithMediaEmbedでRecordEmbedの再利用を改善
- Svelteスニペットによる重複コード解消
- 適切なネスト深度制御の実装

## Test Plan
- [x] TypeScript型チェック通過（0エラー）
- [x] リポストバッジの表示確認
- [x] 多言語切り替えテスト
- [x] 埋め込みコンポーネントの動作確認
- [x] デバッグログの完全削除確認

🤖 Generated with [Claude Code](https://claude.ai/code)