### PR TITLE
YouTube動画埋め込み機能とUI改善

### DIFF
--- a/moodeSky/package.json
+++ b/moodeSky/package.json
@@ -31,6 +31,7 @@
     "hls.js": "^1.6.6",
     "nanoid": "^5.1.5",
     "svelte-dnd-action": "^0.9.61",
+    "svelte-youtube-embed": "^0.4.4",
     "tailwindcss": "^4.1.10"
   },
   "devDependencies": {

--- a/moodeSky/pnpm-lock.yaml
+++ b/moodeSky/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       svelte-dnd-action:
         specifier: ^0.9.61
         version: 0.9.61(svelte@5.34.3)
+      svelte-youtube-embed:
+        specifier: ^0.4.4
+        version: 0.4.4
       tailwindcss:
         specifier: ^4.1.10
         version: 4.1.10
@@ -1328,6 +1331,9 @@ packages:
     resolution: {integrity: sha512-xj0jZNdV44MAMbdGIAuBYEombmK7A7ticemOtdR5ErWw0f3IxcfcnrRjlYEK0rRjsahVsU+VdGUMwjPVyXrSrA==}
     peerDependencies:
       svelte: '>=3.23.0 || ^5.0.0-next.0'
+
+  svelte-youtube-embed@0.4.4:
+    resolution: {integrity: sha512-1F22KeU30xwbfdZcosLlJOkp8YKG9+FHGus4ChxVeIxih/TQKYS4bhGyufr4Kv9zBzP0zKrF5mNyW5hLyfksKQ==}
 
   svelte@5.34.3:
     resolution: {integrity: sha512-Y0QKP2rfWD+ARKe91c4JgZgc/nXa2BfOnVBUjYUMB819m7VyPszihkjdzXPIV0qlGRZYEukpgNq7hgbzTbopJw==}
@@ -2617,6 +2623,10 @@ snapshots:
       - picomatch
 
   svelte-dnd-action@0.9.61(svelte@5.34.3):
+    dependencies:
+      svelte: 5.34.3
+
+  svelte-youtube-embed@0.4.4:
     dependencies:
       svelte: 5.34.3
 

--- a/moodeSky/src/lib/components/embeddings/ExternalLinkEmbed.svelte
+++ b/moodeSky/src/lib/components/embeddings/ExternalLinkEmbed.svelte
@@ -138,7 +138,14 @@
       />
       
       <!-- 動画情報セクション -->
-      <div class="p-3 border-t border-subtle bg-muted/5">
+      <div 
+        class="p-3 border-t border-subtle bg-muted/5 cursor-pointer hover:bg-muted/10 transition-colors"
+        onclick={handleLinkClick}
+        onkeydown={handleKeyDown}
+        role="button"
+        tabindex="0"
+        aria-label="YouTube動画を新しいタブで開く: {linkData().title}"
+      >
         <div class="space-y-1">
           <!-- 動画タイトル -->
           <h3 class="font-medium text-themed text-sm leading-tight line-clamp-2">
@@ -211,10 +218,6 @@
             </div>
           {/if}
           
-          <!-- 外部リンクアイコンオーバーレイ -->
-          <div class="absolute top-1 right-1 w-5 h-5 bg-black/60 rounded-full flex items-center justify-center">
-            <Icon icon={ICONS.OPEN_IN_NEW} size="xs" color="white" />
-          </div>
         </div>
         
         <!-- テキストコンテンツ -->
@@ -263,10 +266,6 @@
               </div>
             </div>
             
-            <!-- 外部リンクアイコン -->
-            <div class="flex-shrink-0 w-8 h-8 bg-muted rounded-full flex items-center justify-center">
-              <Icon icon={ICONS.OPEN_IN_NEW} size="sm" color="secondary" />
-            </div>
           </div>
           
           <!-- 説明文 -->

--- a/moodeSky/src/lib/components/embeddings/ImageEmbed.svelte
+++ b/moodeSky/src/lib/components/embeddings/ImageEmbed.svelte
@@ -328,13 +328,6 @@
     </div>
   {/if}
   
-  {#if images().length > 2 && displayOptions.showImageCount !== false && maxImages > 1}
-    <div class="mt-2 text-center">
-      <span class="text-secondary text-sm">
-        {images().length} 枚の画像
-      </span>
-    </div>
-  {/if}
 </div>
 
 <!--

--- a/moodeSky/src/lib/utils/youtubeUtils.ts
+++ b/moodeSky/src/lib/utils/youtubeUtils.ts
@@ -1,0 +1,247 @@
+/**
+ * YouTube関連のユーティリティ関数
+ * YouTube URL判定、Video ID抽出、メタデータ取得
+ */
+
+/**
+ * URLがYouTubeのURLかどうかを判定
+ * @param url チェックするURL
+ * @returns YouTubeのURLかどうか
+ */
+export function isYouTubeUrl(url: string): boolean {
+  try {
+    const urlObj = new URL(url);
+    const hostname = urlObj.hostname.toLowerCase();
+    
+    // YouTube関連ドメインを判定
+    return (
+      hostname === 'youtube.com' ||
+      hostname === 'www.youtube.com' ||
+      hostname === 'm.youtube.com' ||
+      hostname === 'youtu.be' ||
+      hostname === 'music.youtube.com'
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * YouTube URLからVideo IDを抽出
+ * @param url YouTube URL
+ * @returns Video ID（見つからない場合はnull）
+ */
+export function extractYouTubeId(url: string): string | null {
+  try {
+    const urlObj = new URL(url);
+    const hostname = urlObj.hostname.toLowerCase();
+    
+    // youtu.be短縮URL形式
+    if (hostname === 'youtu.be') {
+      const videoId = urlObj.pathname.slice(1); // 先頭の'/'を除去
+      return isValidVideoId(videoId) ? videoId : null;
+    }
+    
+    // youtube.com標準URL形式
+    if (hostname.includes('youtube.com')) {
+      // /watch?v=VIDEO_ID 形式
+      const videoId = urlObj.searchParams.get('v');
+      if (videoId && isValidVideoId(videoId)) {
+        return videoId;
+      }
+      
+      // /embed/VIDEO_ID 形式
+      const embedMatch = urlObj.pathname.match(/^\/embed\/([a-zA-Z0-9_-]+)/);
+      if (embedMatch && isValidVideoId(embedMatch[1])) {
+        return embedMatch[1];
+      }
+      
+      // /v/VIDEO_ID 形式
+      const vMatch = urlObj.pathname.match(/^\/v\/([a-zA-Z0-9_-]+)/);
+      if (vMatch && isValidVideoId(vMatch[1])) {
+        return vMatch[1];
+      }
+    }
+    
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Video IDが有効な形式かチェック
+ * @param videoId チェックするVideo ID
+ * @returns 有効かどうか
+ */
+function isValidVideoId(videoId: string): boolean {
+  // YouTube Video IDは通常11文字の英数字・ハイフン・アンダースコア
+  return /^[a-zA-Z0-9_-]{10,12}$/.test(videoId);
+}
+
+/**
+ * YouTube動画のサムネイルURLを生成
+ * @param videoId YouTube Video ID
+ * @param quality サムネイル品質 ('default' | 'medium' | 'high' | 'standard' | 'maxres')
+ * @returns サムネイルURL
+ */
+export function getYouTubeThumbnail(
+  videoId: string, 
+  quality: 'default' | 'medium' | 'high' | 'standard' | 'maxres' = 'high'
+): string {
+  const qualityMap = {
+    'default': 'default.jpg',      // 120x90
+    'medium': 'mqdefault.jpg',     // 320x180
+    'high': 'hqdefault.jpg',       // 480x360
+    'standard': 'sddefault.jpg',   // 640x480
+    'maxres': 'maxresdefault.jpg'  // 1280x720
+  };
+  
+  return `https://img.youtube.com/vi/${videoId}/${qualityMap[quality]}`;
+}
+
+/**
+ * YouTube動画のメタデータ型定義
+ */
+export interface YouTubeMetadata {
+  videoId: string;
+  title: string;
+  description: string;
+  thumbnailUrl: string;
+  duration?: string;
+  channelName?: string;
+  viewCount?: number;
+}
+
+/**
+ * YouTube動画のメタデータを取得（簡易版）
+ * @param url YouTube URL
+ * @returns メタデータ（基本情報のみ）
+ */
+export function getYouTubeMetadata(url: string): YouTubeMetadata | null {
+  const videoId = extractYouTubeId(url);
+  if (!videoId) {
+    return null;
+  }
+  
+  return {
+    videoId,
+    title: 'YouTube動画', // 実際のAPIからの取得は将来実装
+    description: '',
+    thumbnailUrl: getYouTubeThumbnail(videoId, 'high')
+  };
+}
+
+/**
+ * YouTube埋め込み用のオプション
+ */
+export interface YouTubeEmbedOptions {
+  /** 自動再生するかどうか */
+  autoplay?: boolean;
+  /** コントロール表示するかどうか */
+  showControls?: boolean;
+  /** YouTube UIを隠すかどうか */
+  modestBranding?: boolean;
+  /** 関連動画を表示するかどうか */
+  showRelated?: boolean;
+  /** プライバシー強化モード */
+  enablePrivacyEnhancedMode?: boolean;
+}
+
+/**
+ * YouTube埋め込み用URLを生成
+ * @param videoId Video ID
+ * @param options 埋め込みオプション
+ * @returns 埋め込み用URL
+ */
+export function generateYouTubeEmbedUrl(
+  videoId: string, 
+  options: YouTubeEmbedOptions = {}
+): string {
+  const {
+    autoplay = false,
+    showControls = true,
+    modestBranding = true,
+    showRelated = false,
+    enablePrivacyEnhancedMode = true
+  } = options;
+  
+  const baseUrl = enablePrivacyEnhancedMode 
+    ? 'https://www.youtube-nocookie.com/embed/' 
+    : 'https://www.youtube.com/embed/';
+  
+  const params = new URLSearchParams({
+    autoplay: autoplay ? '1' : '0',
+    controls: showControls ? '1' : '0',
+    modestbranding: modestBranding ? '1' : '0',
+    rel: showRelated ? '1' : '0'
+  });
+  
+  return `${baseUrl}${videoId}?${params.toString()}`;
+}
+
+/**
+ * YouTubeチャンネルURLかどうかを判定
+ * @param url チェックするURL
+ * @returns チャンネルURLかどうか
+ */
+export function isYouTubeChannelUrl(url: string): boolean {
+  try {
+    const urlObj = new URL(url);
+    const hostname = urlObj.hostname.toLowerCase();
+    
+    if (!hostname.includes('youtube.com')) {
+      return false;
+    }
+    
+    // チャンネルURL形式を判定
+    return (
+      urlObj.pathname.startsWith('/channel/') ||
+      urlObj.pathname.startsWith('/c/') ||
+      urlObj.pathname.startsWith('/user/') ||
+      urlObj.pathname.startsWith('/@')
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * YouTubeプレイリストURLかどうかを判定
+ * @param url チェックするURL
+ * @returns プレイリストURLかどうか
+ */
+export function isYouTubePlaylistUrl(url: string): boolean {
+  try {
+    const urlObj = new URL(url);
+    const hostname = urlObj.hostname.toLowerCase();
+    
+    if (!hostname.includes('youtube.com')) {
+      return false;
+    }
+    
+    // プレイリストURL形式を判定
+    return (
+      urlObj.pathname === '/playlist' ||
+      urlObj.searchParams.has('list')
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * YouTube URL情報を包括的に解析
+ * @param url 解析するURL
+ * @returns URL情報
+ */
+export function analyzeYouTubeUrl(url: string) {
+  return {
+    isYouTube: isYouTubeUrl(url),
+    isVideo: isYouTubeUrl(url) && extractYouTubeId(url) !== null,
+    isChannel: isYouTubeChannelUrl(url),
+    isPlaylist: isYouTubePlaylistUrl(url),
+    videoId: extractYouTubeId(url),
+    metadata: getYouTubeMetadata(url)
+  };
+}


### PR DESCRIPTION
## Summary
- YouTube動画埋め込み機能を実装
- 外部リンク埋め込みのUI改善
- FloatingPostButtonの改善
- セッション管理テスト実装の完了

## 主な変更点

### ✨ 新機能
- **YouTube動画埋め込み**: `svelte-youtube-embed`を使用したYouTube動画の埋め込み表示
- **Pull to Refresh**: タイムラインのプル・ツー・リフレッシュ機能
- **AT Protocol facets対応**: リッチテキスト表示機能
- **モバイル用フローティング投稿ボタン**: モバイル表示での投稿ボタン

### 🎨 UI改善
- 外部リンク埋め込みの外部リンクアイコンを削除
- YouTube埋め込みの動画情報セクションをクリック可能に
- 画像埋め込みの「N枚の画像」表示を削除
- よりクリーンで統一されたUI表示

### 🐛 バグ修正
- 無限スクロールのhasMore判定ロジックを修正
- VideoEmbedの無限読み込み問題を修正
- モバイル表示での埋め込みコンテンツの横幅制限を改善

### 🧪 テスト実装
- セッション管理の包括的テスト実装
- JWT・認証・Token Manager単体テスト
- 極限パフォーマンス・カオステスト
- セキュリティテスト・実用性シナリオテスト

## Test plan
- [x] YouTube動画埋め込みの表示確認
- [x] 外部リンクのクリック動作確認
- [x] モバイル表示での動作確認
- [x] TypeScriptエラーチェック (0件)
- [x] 既存機能の回帰テスト

🤖 Generated with [Claude Code](https://claude.ai/code)